### PR TITLE
Pull request for text wrapping, text alignment fixes + text atlas pad/trimming support

### DIFF
--- a/Assets/DemoSceneScripts/TextManager.cs
+++ b/Assets/DemoSceneScripts/TextManager.cs
@@ -9,6 +9,8 @@ public class TextManager : MonoBehaviour
 	private UITextInstance text3;
 	private UITextInstance text4;
 	
+	private UITextInstance textWrap1;
+	private UITextInstance textWrap2;
 
 	void Start()
 	{
@@ -43,6 +45,18 @@ public class TextManager : MonoBehaviour
 		var center = UIRelative.center( textSize.x, textSize.y );
 		text.addTextInstance( "Be sure to try this with\niPhone and iPad resolutions", center.x, center.y, 1f, 4, Color.red );
 		
+		x = UIRelative.xPercentFrom( UIxAnchor.Left, 0f );
+		y = UIRelative.yPercentFrom( UIyAnchor.Bottom, 0f, textSize.y * 3 );
+		var wrapText = new UIText( "prototype", "prototype.png");
+		wrapText.wrapMode = UITextLineWrapMode.MinimumLength;
+		wrapText.lineWrapWidth = 200.0f;
+		textWrap1 = wrapText.addTextInstance( "Testing line wrap width with small words in multiple resolutions.", x, y, 0.3f);
+		wrapText.lineWrapWidth = 100.0f;
+		wrapText.wrapMode = UITextLineWrapMode.AlwaysHyphenate;
+		x = UIRelative.xPercentFrom( UIxAnchor.Right, 0f, 200.0f );
+		y = UIRelative.yPercentFrom( UIyAnchor.Bottom, 0f, textSize.y * 3 );
+		textWrap2 = wrapText.addTextInstance( "This should be hyphenated.", x, y, 0.5f );
+		
 		StartCoroutine( waitThenRemoveText() );
 	}
 	
@@ -62,6 +76,10 @@ public class TextManager : MonoBehaviour
 		yield return new WaitForSeconds( 1.0f );
 		text4.clear();
 		text2.clear();
+		
+		yield return new WaitForSeconds( 1.0f );
+		textWrap1.clear();
+		textWrap2.clear();
 	}
 
 }

--- a/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
@@ -15,6 +15,7 @@ public struct UITextureInfo
 {
 	public UIUVRect uvRect;
 	public Rect frame;
+	public Rect sourceSize;
 }
 
 
@@ -119,10 +120,18 @@ public class UISpriteManager : MonoBehaviour
 			var frameW = int.Parse( frame["w"].ToString() );
 			var frameH = int.Parse( frame["h"].ToString() );
 		
+			// for trimming support
+			var sourceSize = (Hashtable)((Hashtable)item.Value)["spriteSourceSize"];
+			var sourceSizeX = int.Parse( sourceSize["x"].ToString() );
+			var sourceSizeY = int.Parse( sourceSize["y"].ToString() );
+			var sourceSizeW = int.Parse( sourceSize["w"].ToString() );
+			var sourceSizeH = int.Parse( sourceSize["h"].ToString() );
+			
 			var ti = new UITextureInfo();
 			ti.frame = new Rect( frameX, frameY, frameW, frameH );
 			ti.uvRect = new UIUVRect( frameX, frameY, frameW, frameH, textureSize );
-		
+			ti.sourceSize = new Rect( sourceSizeX, sourceSizeY, sourceSizeW, sourceSizeH );
+			
 			textures.Add( item.Key.ToString(), ti );
 		}
 		


### PR DESCRIPTION
Hi Prime31, 

Thanks for UIToolkit! I needed some basic text wrapping support for one of my projects, and I was thrilled to see that you brought in some Angelcode support into UIToolkit. I added in some simple word wrapping and hyphenation options, and tried to keep your code style where I could. There were some character alignment issues that I believe people referenced in the forum post, and I was able to track it down to a bug with offsetx use as well as pad/trim conflicts arising when TexturePacker trimming metadata wasn't being used in UIText. I put in some comments to the commit to help explain what I did. As I don't use it, I am not certain that sizeForText works, but I modified it to use a wrapped version of text, and commented out a line that looked like a duplicate, and hopefully that's enough. Please let me know if you have any questions. Thanks!

-Gordon Luk (getluky)

---

Two modes of text wrapping are now supported,
UITextLineWrapMode.MinimumLength and 
UITextLineWrapMode.AlwaysHyphenate. 
- MinimumLength will break lines on word boundaries
- AlwaysHyphenate will hyphenate in the middle
  of a word.

Note: Line wrapping incurs allocation and performance
penalties, as the original string is modified!

The text test scene was updated to demonstrate these.

An important bug that was causing horizontal 
misalignment due to improper use of the 'offsetx'
angelcode property was fixed. The property 
'xadvance' should be the only width of a character.
This should restore nice looking spacing between
characters.

The text scene should have nicer-looking text now.

Also, since text atlases coming from programs like
GlyphDesigner may contain padding between characters
and on the atlas margins, there was a problem where
trimming within TexturePacker was not being adjusted
for within the UIText class. This resulted to weird
artifacts and clipped edges in UIText because the
trim offset must be adjusted for when doing UV 
placement. This bug should be fixed now and checking
"Trim" within TexturePacker should be safe for 
GlyphDesigner atlases.
