### PR TITLE
Touch Frame fixes - clip to screen bounds, improve debug areas.

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/UITouchableSprite.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UITouchableSprite.cs
@@ -110,13 +110,24 @@ public abstract class UITouchableSprite : UISprite, IComparable
 					normalFrame.y -= height / 2;
 				}
 
-				_normalTouchFrame = _normalTouchOffsets.addToRect( normalFrame );
-				_highlightedTouchFrame = _highlightedTouchOffsets.addToRect( normalFrame );
+				_normalTouchFrame = addOffsetsAndClipToScreen( normalFrame, _normalTouchOffsets );
+				_highlightedTouchFrame = addOffsetsAndClipToScreen( normalFrame, _highlightedTouchOffsets );
 			}
 			
 			// Either return our highlighted or normal touch frame
 			return ( _highlighted ) ? _highlightedTouchFrame : _normalTouchFrame;
 		}
+	}
+	
+	Rect addOffsetsAndClipToScreen( Rect frame, UIEdgeOffsets offsets )
+	{
+		return Rect.MinMaxRect
+		(
+			 Mathf.Clamp( frame.x - offsets.left, 0, Screen.width ),
+			 Mathf.Clamp( frame.y - offsets.top, 0, Screen.height ),
+			 Mathf.Clamp( frame.x + frame.width + offsets.right, 0, Screen.width),
+			 Mathf.Clamp( frame.y + + frame.height + offsets.bottom, 0, Screen.height)
+		);
 	}
 
 

--- a/Assets/Plugins/UIToolkit/Structs/UIEdgeOffsets.cs
+++ b/Assets/Plugins/UIToolkit/Structs/UIEdgeOffsets.cs
@@ -24,19 +24,4 @@ public struct UIEdgeOffsets
 		this.bottom = bottom * multiplier;
 		this.right = right * multiplier;
 	}
-
-
-	// Used to expand or contract a rect by this
-	public Rect addToRect( Rect frame )
-	{
-		// Clamp x and y to be greater than zero
-		return new Rect
-		(
-			 Mathf.Clamp( frame.x - left, 0, Screen.width ),
-			 Mathf.Clamp( frame.y - top, 0, Screen.height ),
-			 frame.width + right + left,
-			 frame.height + bottom + top
-		);
-	}
-	
 }

--- a/Assets/Plugins/UIToolkit/UIToolkit.cs
+++ b/Assets/Plugins/UIToolkit/UIToolkit.cs
@@ -116,15 +116,7 @@ public class UIToolkit : UISpriteManager
 	   
 		foreach( var item in _touchableSprites )
 		{
-			// touch position varies based on if we have the GO in the center
-			var pos = item.position;
-			if( !item.gameObjectOriginInCenter )
-			{
-				pos.x += item.width / 2;
-				pos.y -= item.height / 2;
-			}
-			
-			// we cant use the touchFrame.x/y directly because it's coordinate space is from the top left
+			var pos = new Vector3( item.touchFrame.x + item.touchFrame.width/2, -( item.touchFrame.y + item.touchFrame.height/2 ), 0 );
 			Gizmos.DrawWireCube( pos, new Vector3( item.touchFrame.width, item.touchFrame.height, 5 ) );
 		}
 		


### PR DESCRIPTION
This is a bugfix for odd behavior where touchable
sprites that extend past the screen bounds had 
touch frames that remained completely in-bounds.

As a result, offscreen buttons would still be
entirely touchable.

Correspondingly, the code for displaying touch areas
in OnDrawGizmos has been refactored to use the 
clipped rects, and (hopefully) no longer depends
on the sprite position. 

Since touch frames are clipped and offsets are added,
both modifications have been moved into 
UITouchableSprite instead of being a two-step process.
- NOTE: In Unity 3.4, there is a bug (414161) where 
  the Screen width/height accessors can return the
  Scene View dimensions instead of the game view 
  in the editor. If clipping bounds in the editor
  look wrong, it may be because of this bug.
