### PR TITLE
Small bugfix to use scaled line wrap widths after first line.

### DIFF
--- a/Assets/Plugins/UIToolkit/UIElements/UIText.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UIText.cs
@@ -577,7 +577,7 @@ public class UIText : System.Object
 						newText +=  "\n" + words[i] + " ";
 					
 						// Reset space left on line
-						spaceLeft = lineWrapWidth - size;
+						spaceLeft = scaledWrapWidth - size;
 					} 
 					else 
 					{


### PR DESCRIPTION
This is a small bugfix for the UIText line wrapping. The earlier code reverted to the non-scaled line wrap width after the first line, so this fixes that. Sorry about that!
