### PR TITLE
Hi - I've fixed a bug where sliders knobs were not being destroyed. Thanks, Jools

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/UISprite.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISprite.cs
@@ -230,7 +230,7 @@ public class UISprite : UIObject, IPositionable
 
 
 	// Removes the sprite from the mesh and destroys it's client GO
-	public void destroy()
+	public virtual void destroy()
 	{
 		manager.removeElement( this );
 	}

--- a/Assets/Plugins/UIToolkit/UIElements/UISlider.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UISlider.cs
@@ -58,7 +58,15 @@ public class UISlider : UITouchableSprite
 		manager.addTouchableSprite( this );
 	}
 
-
+	// Removes the sprite from the mesh and destroys it's client GO
+	public override void destroy()
+	{
+		// pass the call down to our knob
+		_sliderKnob.destroy();
+		
+		base.destroy();
+	}
+	
     public override bool hidden
     {
         get { return ___hidden; }


### PR DESCRIPTION
Previously sliders which were destroy()ed left their knobs behind, unless hidden first. This matches the hidden property.
