### PR TITLE
Sort for UIAbstractTouchableContainer fixed

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/UIAbstractTouchableContainer.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UIAbstractTouchableContainer.cs
@@ -1,12 +1,11 @@
 using UnityEngine;
+using System;
 using System.Collections;
-
-
 
 /// <summary>
 /// Container class that is 
 /// </summary>
-public abstract class UIAbstractTouchableContainer : UIAbstractContainer, ITouchable
+public abstract class UIAbstractTouchableContainer : UIAbstractContainer, ITouchable, IComparable
 {
 	protected UIToolkit _manager; // Reference to the sprite manager in which this sprite resides
 	protected Vector2 _contentSize;

--- a/Assets/Plugins/UIToolkit/UIToolkit.cs
+++ b/Assets/Plugins/UIToolkit/UIToolkit.cs
@@ -160,8 +160,8 @@ public class UIToolkit : UISpriteManager
 		// Add the sprite to our touchables and sort them		
 		_touchableSprites.Add( touchableSprite as ITouchable );
 		
-		// TODO: why does this not work with UIAbstractTouchableContainer?
-		//_touchableSprites.Sort();
+		// Sort the sprites container
+		_touchableSprites.Sort();
 	}
 	
 	


### PR DESCRIPTION
UIAbstractTouchableContainer did not implement IComparable to make sort work.

Re-enabled sort in UIToolkit.
