### PR TITLE
Reworked positioning system to include parenting and additional offset methods.

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/IPositionable.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/IPositionable.cs
@@ -6,5 +6,6 @@ public interface IPositionable
 	float width { get; }
 	float height { get; }
 	Vector3 position { get; set; }
+    UIAnchorInfo anchorInfo { get; set; }
 }
 

--- a/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
@@ -85,6 +85,45 @@ public class UIObject : System.Object, IPositionable
 	}
 
 
+    public virtual Vector3 scale
+    {
+        get
+        {
+            Vector3 localScale = clientTransform.localScale;
+            if (_parentUIObject != null)
+            {
+                Vector3 parentScale = _parentUIObject.localScale;
+                localScale.x *= parentScale.x;
+                localScale.y *= parentScale.y;
+                localScale.z *= parentScale.z;
+            }
+            return localScale;
+        }
+        set
+        {
+            Vector3 localScale = value;
+            if (_parentUIObject != null)
+            {
+                Vector3 parentScale = _parentUIObject.localScale;
+                localScale.x /= parentScale.x;
+                localScale.y /= parentScale.y;
+                localScale.z /= parentScale.z;
+            }
+            clientTransform.localScale = localScale;
+            // If auto refresh is on, don't call onTransformChanged
+            // as it will be called later when position is updated
+            if (autoRefreshPositionOnScaling)
+            {
+                this.refreshPosition();
+            }
+            else
+            {
+                if (onTransformChanged != null)
+                    onTransformChanged();
+            }
+        }
+    }
+
 	public virtual Vector3 localScale
 	{
 		get { return clientTransform.localScale; }

--- a/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
@@ -92,7 +92,7 @@ public class UIObject : System.Object, IPositionable
             Vector3 localScale = clientTransform.localScale;
             if (_parentUIObject != null)
             {
-                Vector3 parentScale = _parentUIObject.localScale;
+                Vector3 parentScale = _parentUIObject.scale;
                 localScale.x *= parentScale.x;
                 localScale.y *= parentScale.y;
                 localScale.z *= parentScale.z;
@@ -104,7 +104,7 @@ public class UIObject : System.Object, IPositionable
             Vector3 localScale = value;
             if (_parentUIObject != null)
             {
-                Vector3 parentScale = _parentUIObject.localScale;
+                Vector3 parentScale = _parentUIObject.scale;
                 localScale.x /= parentScale.x;
                 localScale.y /= parentScale.y;
                 localScale.z /= parentScale.z;

--- a/Assets/Plugins/UIToolkit/BaseElements/UISprite.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISprite.cs
@@ -10,9 +10,9 @@ public class UISprite : UIObject, IPositionable
 	private bool _suspendUpdates; // when true, updateTransform and updateVertPositions will do nothing until endUpdates is called
 	
 	private float _width;
-    public new float width { get { return _width; } }  // Width and Height of the sprite in worldspace units.
+    public new float width { get { return _width * localScale.x; } }  // Width and Height of the sprite in worldspace units.
     private float _height;
-    public new float height { get { return _height; } }
+    public new float height { get { return _height * localScale.y; } }
 	private float _clippedWidth;
 	private float _clippedHeight;
 	public bool gameObjectOriginInCenter = false;  // Set to true to get your origin in the center.  Useful for scaling/rotating
@@ -326,12 +326,13 @@ public class UISprite : UIObject, IPositionable
 		
 		// offset our sprite in the x and y direction to "fix" the change that occurs when we reset to center
 		var pos = clientTransform.position;
-		pos.x += width / 2;
-		pos.y -= height / 2;
+		pos.x += _width / 2;
+		pos.y -= _height / 2;
 		clientTransform.position = pos;
 		
 		gameObjectOriginInCenter = true;
-		setSize( width, height );
+        _anchorInfo.OriginInCenter = true;
+		setSize( _width, _height );
 	}
 	
 

--- a/Assets/Plugins/UIToolkit/BaseElements/UISprite.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISprite.cs
@@ -10,9 +10,9 @@ public class UISprite : UIObject, IPositionable
 	private bool _suspendUpdates; // when true, updateTransform and updateVertPositions will do nothing until endUpdates is called
 	
 	private float _width;
-    public new float width { get { return _width * localScale.x; } }  // Width and Height of the sprite in worldspace units.
+    public new float width { get { return _width * scale.x; } }  // Width and Height of the sprite in worldspace units.
     private float _height;
-    public new float height { get { return _height * localScale.y; } }
+    public new float height { get { return _height * scale.y; } }
 	private float _clippedWidth;
 	private float _clippedHeight;
 	public bool gameObjectOriginInCenter = false;  // Set to true to get your origin in the center.  Useful for scaling/rotating
@@ -179,6 +179,17 @@ public class UISprite : UIObject, IPositionable
 			updateTransform();
 		}
 	}
+
+
+    public override Vector3 scale
+    {
+        get { return base.scale; }
+        set
+        {
+            base.scale = value;
+            updateTransform();
+        }
+    }
 
 
 	public override Vector3 localScale

--- a/Assets/Plugins/UIToolkit/Structs/UIAnchorInfo.cs
+++ b/Assets/Plugins/UIToolkit/Structs/UIAnchorInfo.cs
@@ -1,0 +1,46 @@
+using UnityEngine;
+
+/// <summary>
+/// Holds information about positioning anchors
+/// </summary>
+public struct UIAnchorInfo
+{
+    public IPositionable ParentUIObject;
+    public UIxAnchor ParentUIxAnchor;
+    public UIyAnchor ParentUIyAnchor;
+    public UIxAnchor UIxAnchor;
+    public UIyAnchor UIyAnchor;
+    public UIPrecision UIPrecision;
+    public float OffsetX;
+    public float OffsetY;
+    public bool OriginInCenter;
+
+    /// <summary>
+    /// Creates a default anchor info object anchored to top left corner.
+    /// </summary>
+    /// <returns>Default anchor info object</returns>
+    public static UIAnchorInfo DefaultAnchorInfo()
+    {
+        UIAnchorInfo anchorInfo = new UIAnchorInfo()
+        {
+            ParentUIObject = null,
+            ParentUIxAnchor = UIxAnchor.Left,
+            ParentUIyAnchor = UIyAnchor.Top,
+            UIxAnchor = UIxAnchor.Left,
+            UIyAnchor = UIyAnchor.Top,
+            UIPrecision = UIPrecision.Percentage,
+            OffsetX = 0f,
+            OffsetY = 0f,
+            OriginInCenter = false
+        };
+        return anchorInfo;
+    }
+
+#if UNITY_EDITOR
+    public override string ToString()
+    {
+        return string.Format("Parent UIObject: {0:g}\nParent UIxAnchor: {1}\nParent UIyAnchor: {2}\nUIxAnchor: {3}\nUIyAnchor: {4}\nUIPrecision: {5}\nOffsetX: {6}\nOffsetY: {7}\nOriginInCenter: {8}",
+            ParentUIObject, ParentUIxAnchor, ParentUIyAnchor, UIxAnchor, UIyAnchor, UIPrecision, OffsetX, OffsetY, OriginInCenter);
+    }
+#endif
+}

--- a/Assets/Plugins/UIToolkit/Structs/UIAnchorInfo.cs.meta
+++ b/Assets/Plugins/UIToolkit/Structs/UIAnchorInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 1
+guid: 118952c93964daa42b07a01de080e2f3

--- a/Assets/Plugins/UIToolkit/Support/IPositionablePositioningExtensions.cs
+++ b/Assets/Plugins/UIToolkit/Support/IPositionablePositioningExtensions.cs
@@ -1,156 +1,934 @@
 using UnityEngine;
-using System.Collections;
-
 
 public static class IPositionablePositioningExtensions
 {
-	/// <summary>
-	/// Positions a sprite in the center of the screen
-	/// </summary
-	public static void positionCenter( this IPositionable sprite )
-	{
-		var pos = sprite.position;
-		var centerPos = UIRelative.center( sprite.width, sprite.height );
-		pos.x = centerPos.x;
-		pos.y = -centerPos.y;
-		
-		sprite.position = pos;
-	}
-	
-	
-	/// <summary>
-	/// Positions a sprite in the center on x axis
-	/// </summary
-	public static void positionCenterX( this IPositionable sprite )
-	{
-		var centerPos = UIRelative.center( sprite.width, sprite.height );
-		sprite.position =  new Vector2( centerPos.x, sprite.position.y );
-	}
+    #region Relative offset methods
 
+    /// <summary>
+    /// Positions a sprite in the center of its parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    public static void positionCenter(this IPositionable sprite)
+    {
+        sprite.positionFromCenter(0f, 0f);
+    }
 
-	/// <summary>
-	/// Positions a sprite in the center on y axis
-	/// </summary
-	public static void positionCenterY( this IPositionable sprite )
-	{
-		var centerPos = UIRelative.center( sprite.width, sprite.height );
-		sprite.position = new Vector2( sprite.position.x, -centerPos.y );
-	}
+    /// <summary>
+    /// Positions a sprite relatively to the center of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    public static void positionFromCenter(this IPositionable sprite, float percentFromTop, float percentFromLeft)
+    {
+        sprite.positionFromCenter(percentFromTop, percentFromLeft, UIyAnchor.Center, UIxAnchor.Center);
+    }
 
+    /// <summary>
+    /// Positions a sprite relatively to the center of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromCenter(this IPositionable sprite, float percentFromTop, float percentFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Center;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Center;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromLeft;
+        anchorInfo.OffsetY = percentFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
 
-	/// <summary>
-	/// Positions a sprite relatively from the top-left corner of the screen.  Values are percentage of screen width/height to move away from the corner.
-	/// </summary
-	public static void positionFromTopLeft( this IPositionable sprite, float percentFromTop, float percentFromLeft )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPercentFrom( UIxAnchor.Left, percentFromLeft );
-		pos.y = -UIRelative.yPercentFrom( UIyAnchor.Top, percentFromTop );
-		
-		sprite.position = pos;
-	}
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
 
+        // Refresh position
+        sprite.refreshPosition();
+    }
 
-	/// <summary>
-	/// Positions a sprite relatively from the top-right corner of the screen.  Values are percentage of screen width/height to move away from the corner.
-	/// The right boundary will be measured from the sprites right-most point
-	/// </summary
-	public static void positionFromTopRight( this IPositionable sprite, float percentFromTop, float percentFromRight )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPercentFrom( UIxAnchor.Right, percentFromRight, sprite.width );
-		pos.y = -UIRelative.yPercentFrom( UIyAnchor.Top, percentFromTop );
-		
-		sprite.position = pos;
-	}
+    /// <summary>
+    /// Positions a sprite relatively to the top-left corner of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    public static void positionFromTopLeft(this IPositionable sprite, float percentFromTop, float percentFromLeft)
+    {
+        sprite.positionFromTopLeft(percentFromTop, percentFromLeft, UIyAnchor.Top, UIxAnchor.Left);
+    }
 
+    /// <summary>
+    /// Positions a sprite relatively to the top-left corner of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromTopLeft(this IPositionable sprite, float percentFromTop, float percentFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Left;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Top;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromLeft;
+        anchorInfo.OffsetY = percentFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
 
-	/// <summary>
-	/// Positions a sprite relatively from the bottom-left corner of the screen.  Values are percentage of screen width/height to move away from the corner.
-	/// The bottom boundary will be measured from the sprites bottom-most point
-	/// </summary
-	public static void positionFromBottomLeft( this IPositionable sprite, float percentFromBottom, float percentFromLeft )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPercentFrom( UIxAnchor.Left, percentFromLeft );
-		pos.y = -UIRelative.yPercentFrom( UIyAnchor.Bottom, percentFromBottom, sprite.height );
-		
-		sprite.position = pos;
-	}
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
 
+        // Refresh position
+        sprite.refreshPosition();
+    }
 
-	/// <summary>
-	/// Positions a sprite relatively from the bottom-right corner of the screen.  Values are percentage of screen width/height to move away from the corner.
-	/// The right boundary will be measured from the sprites right-most point
-	/// The bottom boundary will be measured from the sprites bottom-most point
-	/// </summary
-	public static void positionFromBottomRight( this IPositionable sprite, float percentFromBottom, float percentFromRight )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPercentFrom( UIxAnchor.Right, percentFromRight, sprite.width );
-		pos.y = -UIRelative.yPercentFrom( UIyAnchor.Bottom, percentFromBottom, sprite.height );
-		
-		sprite.position = pos;
-	}
+    /// <summary>
+    /// Positions a sprite relatively to the top-right corner of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromRight">Percentage from right - positive values places the sprite closer to the left</param>
+    public static void positionFromTopRight(this IPositionable sprite, float percentFromTop, float percentFromRight)
+    {
+        sprite.positionFromTopRight(percentFromTop, percentFromRight, UIyAnchor.Top, UIxAnchor.Right);
+    }
 
+    /// <summary>
+    /// Positions a sprite relatively to the top-right corner of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromRight">Percentage from right - positive values places the sprite closer to the left</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromTopRight(this IPositionable sprite, float percentFromTop, float percentFromRight, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Right;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Top;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromRight;
+        anchorInfo.OffsetY = percentFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
 
-	#region Pixel offset methods
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
 
-	/// <summary>
-	/// Positions a sprite relatively from the top-left corner of the screen.  Values are pixels from the corner.
-	/// </summary
-	public static void pixelsFromTopLeft( this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPixelsFrom( UIxAnchor.Left, pixelsFromLeft );
-		pos.y = -UIRelative.yPixelsFrom( UIyAnchor.Top, pixelsFromTop );
-		
-		sprite.position = pos;
-	}
+        // Refresh position
+        sprite.refreshPosition();
+    }
 
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-left corner of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromBottom">Percentage from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    public static void positionFromBottomLeft(this IPositionable sprite, float percentFromBottom, float percentFromLeft)
+    {
+        sprite.positionFromBottomLeft(percentFromBottom, percentFromLeft, UIyAnchor.Bottom, UIxAnchor.Left);
+    }
 
-	/// <summary>
-	/// Positions a sprite relatively from the top-right corner of the screen.  Values are pixels from the corner.
-	/// The right boundary will be measured from the sprites right-most point
-	/// </summary
-	public static void pixelsFromTopRight( this IPositionable sprite, int pixelsFromTop, int pixelsFromRight )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPixelsFrom( UIxAnchor.Right, pixelsFromRight, sprite.width );
-		pos.y = -UIRelative.yPixelsFrom( UIyAnchor.Top, pixelsFromTop );
-		
-		sprite.position = pos;
-	}
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-left corner of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromBottom">Percentage from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromBottomLeft(this IPositionable sprite, float percentFromBottom, float percentFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Left;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Bottom;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromLeft;
+        anchorInfo.OffsetY = percentFromBottom;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
 
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
 
-	/// <summary>
-	/// Positions a sprite relatively from the bottom-left corner of the screen.  Values are pixels from the corner.
-	/// The bottom boundary will be measured from the sprites bottom-most point
-	/// </summary
-	public static void pixelsFromBottomLeft( this IPositionable sprite, int pixelsFromBottom, int pixelsFromLeft )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPixelsFrom( UIxAnchor.Left, pixelsFromLeft );
-		pos.y = -UIRelative.yPixelsFrom( UIyAnchor.Bottom, pixelsFromBottom, sprite.height );
-		
-		sprite.position = pos;
-	}
+        // Refresh position
+        sprite.refreshPosition();
+    }
 
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-right corner of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromBottom">Percentage from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="percentFromRight">Percentage from right - positive values places the sprite closer to the left</param>
+    public static void positionFromBottomRight(this IPositionable sprite, float percentFromBottom, float percentFromRight)
+    {
+        sprite.positionFromBottomRight(percentFromBottom, percentFromRight, UIyAnchor.Bottom, UIxAnchor.Right);
+    }
 
-	/// <summary>
-	/// Positions a sprite relatively from the bottom-right corner of the screen.  Values are pixels from the corner.
-	/// The right boundary will be measured from the sprites right-most point
-	/// The bottom boundary will be measured from the sprites bottom-most point
-	/// </summary
-	public static void pixelsFromBottomRight( this IPositionable sprite, int pixelsFromBottom, int pixelsFromRight )
-	{
-		var pos = sprite.position;
-		pos.x = UIRelative.xPixelsFrom( UIxAnchor.Right, pixelsFromRight, sprite.width );
-		pos.y = -UIRelative.yPixelsFrom( UIyAnchor.Bottom, pixelsFromBottom, sprite.height );
-		
-		sprite.position = pos;
-	}
-	
-	#endregion
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-right corner of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromBottom">Percentage from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="percentFromRight">Percentage from right - positive values places the sprite closer to the left</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromBottomRight(this IPositionable sprite, float percentFromBottom, float percentFromRight, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Right;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Bottom;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromRight;
+        anchorInfo.OffsetY = percentFromBottom;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-center of its parent.
+    /// Value is percentage of screen height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    public static void positionFromTop(this IPositionable sprite, float percentFromTop)
+    {
+        sprite.positionFromTop(percentFromTop, 0f, UIyAnchor.Top, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-center of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    public static void positionFromTop(this IPositionable sprite, float percentFromTop, float percentFromLeft)
+    {
+        sprite.positionFromTop(percentFromTop, percentFromLeft, UIyAnchor.Top, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-center of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromTop(this IPositionable sprite, float percentFromTop, float percentFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Center;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Top;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromLeft;
+        anchorInfo.OffsetY = percentFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-center of its parent.
+    /// Value is percentage of screen height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromBottom">Percentage from bottom - positive values places the sprite closer to the top</param>
+    public static void positionFromBottom(this IPositionable sprite, float percentFromBottom)
+    {
+        sprite.positionFromBottom(percentFromBottom, 0f, UIyAnchor.Bottom, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-center of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromBottom">Percentage from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    public static void positionFromBottom(this IPositionable sprite, float percentFromBottom, float percentFromLeft)
+    {
+        sprite.positionFromBottom(percentFromBottom, percentFromLeft, UIyAnchor.Bottom, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-center of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromBottom">Percentage from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromBottom(this IPositionable sprite, float percentFromBottom, float percentFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Center;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Bottom;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromLeft;
+        anchorInfo.OffsetY = percentFromBottom;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-left of its parent.
+    /// Value is percentage of screen width to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    public static void positionFromLeft(this IPositionable sprite, float percentFromLeft)
+    {
+        sprite.positionFromLeft(0f, percentFromLeft, UIyAnchor.Center, UIxAnchor.Left);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-left of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    public static void positionFromLeft(this IPositionable sprite, float percentFromTop, float percentFromLeft)
+    {
+        sprite.positionFromLeft(percentFromTop, percentFromLeft, UIyAnchor.Center, UIxAnchor.Left);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-left of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromLeft">Percentage from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromLeft(this IPositionable sprite, float percentFromTop, float percentFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Left;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Center;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromLeft;
+        anchorInfo.OffsetY = percentFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-right of its parent.
+    /// Value is percentage of screen width to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromRight">Percentage from right - positive values places the sprite closer to the left</param>
+    public static void positionFromRight(this IPositionable sprite, float percentFromRight)
+    {
+        sprite.positionFromRight(0f, percentFromRight, UIyAnchor.Center, UIxAnchor.Right);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-right of its parent.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromRight">Percentage from right - positive values places the sprite closer to the left</param>
+    public static void positionFromRight(this IPositionable sprite, float percentFromTop, float percentFromRight)
+    {
+        sprite.positionFromRight(percentFromTop, percentFromRight, UIyAnchor.Center, UIxAnchor.Right);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-right of its parent, with specific local anchors.
+    /// Values are percentage of screen width/height to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="percentFromTop">Percentage from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="percentFromRight">Percentage from right - positive values places the sprite closer to the left</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void positionFromRight(this IPositionable sprite, float percentFromTop, float percentFromRight, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Right;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Center;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = percentFromRight;
+        anchorInfo.OffsetY = percentFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Percentage;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    #endregion
+
+    #region Pixel offset methods
+
+    /// <summary>
+    /// Positions a sprite relatively to the center of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    public static void pixelsFromCenter(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft)
+    {
+        sprite.pixelsFromCenter(pixelsFromTop, pixelsFromLeft, UIyAnchor.Center, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromCenter(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Center;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Center;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromLeft;
+        anchorInfo.OffsetY = pixelsFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-left corner of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    public static void pixelsFromTopLeft(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft)
+    {
+        sprite.pixelsFromTopLeft(pixelsFromTop, pixelsFromLeft, UIyAnchor.Top, UIxAnchor.Left);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-left corner of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromTopLeft(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Left;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Top;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromLeft;
+        anchorInfo.OffsetY = pixelsFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-right corner of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromRight">Pixels from right - positive values places the sprite closer to the left</param>
+    public static void pixelsFromTopRight(this IPositionable sprite, int pixelsFromTop, int pixelsFromRight)
+    {
+        sprite.pixelsFromTopRight(pixelsFromTop, pixelsFromRight, UIyAnchor.Top, UIxAnchor.Right);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-right corner of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromRight">Pixels from right - positive values places the sprite closer to the left</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromTopRight(this IPositionable sprite, int pixelsFromTop, int pixelsFromRight, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Right;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Top;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromRight;
+        anchorInfo.OffsetY = pixelsFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-left corner of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromBottom">Pixels from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    public static void pixelsFromBottomLeft(this IPositionable sprite, int pixelsFromBottom, int pixelsFromLeft)
+    {
+        sprite.pixelsFromBottomLeft(pixelsFromBottom, pixelsFromLeft, UIyAnchor.Bottom, UIxAnchor.Left);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-left corner of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromBottom">Pixels from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromBottomLeft(this IPositionable sprite, int pixelsFromBottom, int pixelsFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Left;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Bottom;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromLeft;
+        anchorInfo.OffsetY = pixelsFromBottom;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-right corner of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromBottom">Pixels from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="pixelsFromRight">Pixels from right - positive values places the sprite closer to the left</param>
+    public static void pixelsFromBottomRight(this IPositionable sprite, int pixelsFromBottom, int pixelsFromRight)
+    {
+        sprite.pixelsFromBottomRight(pixelsFromBottom, pixelsFromRight, UIyAnchor.Bottom, UIxAnchor.Right);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-right corner of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromBottom">Pixels from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="pixelsFromRight">Pixels from right - positive values places the sprite closer to the left</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromBottomRight(this IPositionable sprite, int pixelsFromBottom, int pixelsFromRight, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Right;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Bottom;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromRight;
+        anchorInfo.OffsetY = pixelsFromBottom;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-center of its parents.
+    /// Value is pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    public static void pixelsFromTop(this IPositionable sprite, int pixelsFromTop)
+    {
+        sprite.pixelsFromTop(pixelsFromTop, 0, UIyAnchor.Top, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-center of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    public static void pixelsFromTop(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft)
+    {
+        sprite.pixelsFromTop(pixelsFromTop, pixelsFromLeft, UIyAnchor.Top, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the top-center of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromTop(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Center;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Top;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromLeft;
+        anchorInfo.OffsetY = pixelsFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-center of its parents.
+    /// Value is pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromBottom">Pixels from bottom - positive values places the sprite closer to the top</param>
+    public static void pixelsFromBottom(this IPositionable sprite, int pixelsFromBottom)
+    {
+        sprite.pixelsFromBottom(pixelsFromBottom, 0, UIyAnchor.Bottom, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-center of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromBottom">Pixels from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    public static void pixelsFromBottom(this IPositionable sprite, int pixelsFromBottom, int pixelsFromLeft)
+    {
+        sprite.pixelsFromBottom(pixelsFromBottom, pixelsFromLeft, UIyAnchor.Bottom, UIxAnchor.Center);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the bottom-center of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromBottom">Pixels from bottom - positive values places the sprite closer to the top</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromBottom(this IPositionable sprite, int pixelsFromBottom, int pixelsFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Center;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Bottom;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromLeft;
+        anchorInfo.OffsetY = pixelsFromBottom;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-left of its parent.
+    /// Value is pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    public static void pixelsFromLeft(this IPositionable sprite, int pixelsFromLeft)
+    {
+        sprite.pixelsFromLeft(0, pixelsFromLeft, UIyAnchor.Center, UIxAnchor.Left);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-left of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    public static void pixelsFromLeft(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft)
+    {
+        sprite.pixelsFromLeft(pixelsFromTop, pixelsFromLeft, UIyAnchor.Center, UIxAnchor.Left);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-left of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromLeft">Pixels from left - positive values places the sprite closer to the right</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromLeft(this IPositionable sprite, int pixelsFromTop, int pixelsFromLeft, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Left;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Center;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromLeft;
+        anchorInfo.OffsetY = pixelsFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-right of its parent.
+    /// Value is pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromRight">Pixels from right - positive values places the sprite closer to the left</param>
+    public static void pixelsFromRight(this IPositionable sprite, int pixelsFromRight)
+    {
+        sprite.pixelsFromRight(0, pixelsFromRight, UIyAnchor.Center, UIxAnchor.Right);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-right of its parent.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromRight">Pixels from right - positive values places the sprite closer to the left</param>
+    public static void pixelsFromRight(this IPositionable sprite, int pixelsFromTop, int pixelsFromRight)
+    {
+        sprite.pixelsFromRight(pixelsFromTop, pixelsFromRight, UIyAnchor.Center, UIxAnchor.Right);
+    }
+
+    /// <summary>
+    /// Positions a sprite relatively to the center-right of its parent, with specific local anchors.
+    /// Values are pixels to move away from the parent.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="pixelsFromTop">Pixels from top - positive values places the sprite closer to the bottom</param>
+    /// <param name="pixelsFromRight">Pixels from right - positive values places the sprite closer to the left</param>
+    /// <param name="yAnchor">Sprite vertical anchor</param>
+    /// <param name="xAnchor">Sprite horizontal anchor</param>
+    public static void pixelsFromRight(this IPositionable sprite, int pixelsFromTop, int pixelsFromRight, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        // Update anchor information
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+        anchorInfo.ParentUIxAnchor = UIxAnchor.Right;
+        anchorInfo.ParentUIyAnchor = UIyAnchor.Center;
+        anchorInfo.UIxAnchor = xAnchor;
+        anchorInfo.UIyAnchor = yAnchor;
+        anchorInfo.OffsetX = pixelsFromRight;
+        anchorInfo.OffsetY = pixelsFromTop;
+        anchorInfo.UIPrecision = UIPrecision.Pixel;
+
+        // Set new anchor information
+        sprite.anchorInfo = anchorInfo;
+
+        // Refresh position
+        sprite.refreshPosition();
+    }
+
+    #endregion
+
+    /// <summary>
+    /// Adjusts anchor offsets for a new parent anchor and updates the sprite's anchor infomation.
+    /// </summary>
+    /// <param name="sprite"></param>
+    /// <param name="newParent"></param>
+    public static void adjustAnchorForNewParent(this IPositionable sprite, IPositionable newParent)
+    {
+        // Get anchor info
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+
+        // Get parent anchors
+        Vector3 oldParentAnchorPosition = parentAnchorPosition(anchorInfo.ParentUIObject, anchorInfo.ParentUIyAnchor, anchorInfo.ParentUIxAnchor);
+        Vector3 newParentAnchorPosition = parentAnchorPosition(newParent, anchorInfo.ParentUIyAnchor, anchorInfo.ParentUIxAnchor);
+        Vector3 diffAnchor = newParentAnchorPosition - oldParentAnchorPosition;
+
+        // Adjust for sprite anchor offset
+        diffAnchor.x -= UIRelative.xAnchorAdjustment(anchorInfo.UIxAnchor, sprite.width, anchorInfo.OriginInCenter);
+        diffAnchor.y += UIRelative.yAnchorAdjustment(anchorInfo.UIyAnchor, sprite.height, anchorInfo.OriginInCenter);
+
+        // Adjust parent anchor offsets
+        if (anchorInfo.UIPrecision == UIPrecision.Percentage)
+        {
+            anchorInfo.OffsetX += UIRelative.xPercentTo(anchorInfo.UIxAnchor, diffAnchor.x);
+            anchorInfo.OffsetY -= UIRelative.yPercentTo(anchorInfo.UIyAnchor, diffAnchor.y);
+        }
+        else
+        {
+            anchorInfo.OffsetX += UIRelative.xPixelsTo(anchorInfo.UIxAnchor, diffAnchor.x);
+            anchorInfo.OffsetY -= UIRelative.yPixelsTo(anchorInfo.UIyAnchor, diffAnchor.y);
+        }
+
+        // Update parent
+        anchorInfo.ParentUIObject = newParent;
+
+        // Set update anchor info
+        sprite.anchorInfo = anchorInfo;
+    }
+
+    /// <summary>
+    /// Refreshes the sprite's position according to its anchor information.
+    /// </summary>
+    /// <param name="sprite"></param>
+    public static void refreshPosition(this IPositionable sprite)
+    {
+        // Get anchor info
+        UIAnchorInfo anchorInfo = sprite.anchorInfo;
+
+        // Get parent anchor position
+        Vector3 position = parentAnchorPosition(anchorInfo.ParentUIObject, anchorInfo.ParentUIyAnchor, anchorInfo.ParentUIxAnchor);
+
+        // Add position offset
+        if (anchorInfo.UIPrecision == UIPrecision.Percentage)
+        {
+            position.x += UIRelative.xPercentFrom(anchorInfo.UIxAnchor, anchorInfo.OffsetX);
+            position.y -= UIRelative.yPercentFrom(anchorInfo.UIyAnchor, anchorInfo.OffsetY);
+        }
+        else
+        {
+            position.x += UIRelative.xPixelsFrom(anchorInfo.UIxAnchor, anchorInfo.OffsetX);
+            position.y -= UIRelative.yPixelsFrom(anchorInfo.UIyAnchor, anchorInfo.OffsetY);
+        }
+
+        // Adjust for anchor offset
+        position.x -= UIRelative.xAnchorAdjustment(anchorInfo.UIxAnchor, sprite.width, anchorInfo.OriginInCenter);
+        position.y += UIRelative.yAnchorAdjustment(anchorInfo.UIyAnchor, sprite.height, anchorInfo.OriginInCenter);
+
+        // Set new position
+        sprite.position = position;
+    }
+
+    /// <summary>
+    /// Returns anchor position for a given parent and fallback to Screen if parent is null.
+    /// </summary>
+    /// <param name="sprite">Provided parent</param>
+    /// <param name="yAnchor">Vertical anchor</param>
+    /// <param name="xAnchor">Horizontal anchor</param>
+    /// <returns>Adjusted anchor position</returns>
+    private static Vector3 parentAnchorPosition(IPositionable sprite, UIyAnchor yAnchor, UIxAnchor xAnchor)
+    {
+        Vector3 position;
+        float width, height;
+        bool originInCenter = false;
+        // Determine correct parent values
+        if (sprite == null)
+        {
+            position = Vector3.zero;
+            width = Screen.width;
+            height = Screen.height;
+        }
+        else
+        {
+            position = sprite.position;
+            width = sprite.width;
+            height = sprite.height;
+            originInCenter = sprite.anchorInfo.OriginInCenter;
+        }
+
+        // Adjust anchor offset
+        position.x += UIRelative.xAnchorAdjustment(xAnchor, width, originInCenter);
+        position.y -= UIRelative.yAnchorAdjustment(yAnchor, height, originInCenter);
+
+        return position;
+    }
 
 }

--- a/Assets/Plugins/UIToolkit/Support/UIObjectAnimationExtensions.cs
+++ b/Assets/Plugins/UIToolkit/Support/UIObjectAnimationExtensions.cs
@@ -68,19 +68,19 @@ public static class UIObjectAnimationExtensions
 	// local scale
 	public static UIAnimation scaleTo( this UIObject sprite, float duration, Vector3 target, UIEaseType ease )
 	{
-		return to( sprite, duration, UIAnimationProperty.LocalScale, target, ease );
+		return to( sprite, duration, UIAnimationProperty.Scale, target, ease );
 	}
 	
 
 	public static UIAnimation scaleFrom( this UIObject sprite, float duration, Vector3 target, UIEaseType ease )
 	{
-		return from( sprite, duration, UIAnimationProperty.LocalScale, target, ease );
+		return from( sprite, duration, UIAnimationProperty.Scale, target, ease );
 	}
 	
 	
 	public static UIAnimation scaleFromTo( this UIObject sprite, float duration, Vector3 start, Vector3 target, UIEaseType ease )
 	{
-		return fromTo( sprite, duration, UIAnimationProperty.LocalScale, start, target, ease );
+		return fromTo( sprite, duration, UIAnimationProperty.Scale, start, target, ease );
 	}
 
 
@@ -240,8 +240,8 @@ public static class UIObjectAnimationExtensions
 			case UIAnimationProperty.Position:
 				current = sprite.localPosition;
 				break;
-			case UIAnimationProperty.LocalScale:
-				current = sprite.localScale;
+			case UIAnimationProperty.Scale:
+				current = sprite.scale;
 				break;
 			case UIAnimationProperty.EulerAngles:
 				current = sprite.eulerAngles;

--- a/Assets/Plugins/UIToolkit/Support/UIRelative.cs
+++ b/Assets/Plugins/UIToolkit/Support/UIRelative.cs
@@ -1,122 +1,248 @@
 using UnityEngine;
-using System.Collections;
 
-
-public enum UIxAnchor { Left, Right };
-public enum UIyAnchor { Top, Bottom };
-
+public enum UIxAnchor { Left, Right, Center };
+public enum UIyAnchor { Top, Bottom, Center };
+public enum UIPrecision { Percentage, Pixel };
 
 public static class UIRelative
 {
-	/// <summary>
-	/// Determine if running in HD and multiply pixelOffsets accordingly.
-	/// </summary>
-	public static int pixelDensityMultiplier()
-	{
-		return UI.instance.isHD ? 2 : 1;
-	}
+    /// <summary>
+    /// Determine if running in HD and multiply pixelOffsets accordingly.
+    /// </summary>
+    public static int pixelDensityMultiplier()
+    {
+        return UI.instance.isHD ? 2 : 1;
+    }
 
-	
-	/// <summary>
-	/// Percent to offset from the anchor.  If the anchor is right, the width will be used to make the offset
-	/// from the right-most point of the sprite.
-	/// </summary>
-	public static float xPercentFrom( UIxAnchor anchor, float percentOffset )
-	{
-		return xPercentFrom( anchor, percentOffset, 0 );
-	}
+    #region Relative offset methods
 
+    /// <summary>
+    /// Calculates offset based on screen width percentage.
+    /// </summary>
+    /// <param name="anchor">Sprite horizontal anchor</param>
+    /// <param name="percentOffset">Percentage offset - 1 is 100%</param>
+    /// <returns></returns>
+    public static float xPercentFrom(UIxAnchor anchor, float percentOffset)
+    {
+        // Get inital offset
+        float offset = Screen.width * percentOffset;
+        // If anchor is right the offset is flipped
+        if (anchor == UIxAnchor.Right)
+        {
+            offset = -offset;
+        }
+        return offset;
+    }
 
-	public static float xPercentFrom( UIxAnchor anchor, float percentOffset, float width )
-	{
-		switch( anchor )
-		{
-			case UIxAnchor.Left:
-				return percentOffset * Screen.width;
-			case UIxAnchor.Right:
-				return Screen.width - ( percentOffset * Screen.width ) - width;
-		}
-		return 0f;
-	}
+    /// <summary>
+    /// Calculates offset based on screen height percentage.
+    /// </summary>
+    /// <param name="anchor">Sprite vertical anchor</param>
+    /// <param name="percentOffset">Percentage offset - 1 is 100%</param>
+    /// <returns></returns>
+    public static float yPercentFrom(UIyAnchor anchor, float percentOffset)
+    {
+        // Get initial offset
+        float offset = Screen.height * percentOffset;
+        // If anchor is bottom the offset is flipped
+        if (anchor == UIyAnchor.Bottom)
+        {
+            offset = -offset;
+        }
+        return offset;
+    }
 
+    /// <summary>
+    /// Calculates screen width percentage based on offset.
+    /// </summary>
+    /// <param name="anchor">Sprite horizontal anchor</param>
+    /// <param name="offset">Position offset</param>
+    /// <returns></returns>
+    public static float xPercentTo(UIxAnchor anchor, float offset)
+    {
+        // Get initial percentage
+        float percentOffset = offset / Screen.width;
+        // If anchor isn't right the percentage is flipped
+        if (anchor != UIxAnchor.Right)
+        {
+            percentOffset = -percentOffset;
+        }
+        return percentOffset;
+    }
 
-	/// <summary>
-	/// Pixels to offset from the anchor.  If the anchor is right, the width will be used to make the offset
-	/// from the right-most point of the sprite.
-	/// </summary>
-	public static float xPixelsFrom( UIxAnchor anchor, int pixelOffset )
-	{
-		return xPixelsFrom( anchor, pixelOffset, 0 );
-	}
+    /// <summary>
+    /// Calculates screen height percentage based on offset.
+    /// </summary>
+    /// <param name="anchor">Sprite vertical anchor</param>
+    /// <param name="offset">Position offset</param>
+    /// <returns></returns>
+    public static float yPercentTo(UIyAnchor anchor, float offset)
+    {
+        // Get initial percentage
+        float percentOffset = offset / Screen.height;
+        // If anchor isn't bottom the percentage is flipped
+        if (anchor != UIyAnchor.Bottom)
+        {
+            percentOffset = -percentOffset;
+        }
+        return percentOffset;
+    }
 
+    #endregion
 
-	public static float xPixelsFrom( UIxAnchor anchor, int pixelOffset, float width )
-	{
-		switch( anchor )
-		{
-			case UIxAnchor.Left:
-				return pixelOffset * pixelDensityMultiplier();
-			case UIxAnchor.Right:
-				return Screen.width - pixelOffset*pixelDensityMultiplier() - width;
-		}
-		return 0f;
-	}
+    #region Pixel offset methods
 
+    /// <summary>
+    /// Calculates horizontal pixel offset based on SD or HD.
+    /// </summary>
+    /// <param name="anchor">Sprite horizontal anchor</param>
+    /// <param name="pixelOffset">Fixed offset</param>
+    /// <returns></returns>
+    public static float xPixelsFrom(UIxAnchor anchor, float pixelOffset)
+    {
+        // Get initial offset
+        float offset = pixelOffset * pixelDensityMultiplier();
+        // If anchor is right the offset is flipped
+        if (anchor == UIxAnchor.Right)
+        {
+            offset = -offset;
+        }
+        return offset;
+    }
 
-	/// <summary>
-	/// Percent to offset from the anchor.  If the anchor is bottom, the height will be used to make the offset
-	/// from the height-most point of the sprite.
-	/// </summary>
-	public static float yPercentFrom( UIyAnchor anchor, float percentOffset )
-	{
-		return yPercentFrom( anchor, percentOffset, 0 );
-	}
+    /// <summary>
+    /// Calculates vertical pixel offset based on SD or HD.
+    /// </summary>
+    /// <param name="anchor">Sprite vertical anchor</param>
+    /// <param name="pixelOffset">Fixed offset</param>
+    /// <returns></returns>
+    public static float yPixelsFrom(UIyAnchor anchor, float pixelOffset)
+    {
+        // Get initial offset
+        float offset = pixelOffset * pixelDensityMultiplier();
+        // If anchor is bottom the offset is flipped
+        if (anchor == UIyAnchor.Bottom)
+        {
+            offset = -offset;
+        }
+        return offset;
+    }
 
+    /// <summary>
+    /// Calculates fixed horizontal pixel offset based on SD or HD offset.
+    /// </summary>
+    /// <param name="anchor">Sprite horizontal anchor</param>
+    /// <param name="offset">Relative offset</param>
+    /// <returns></returns>
+    public static float xPixelsTo(UIxAnchor anchor, float offset)
+    {
+        // Get initial fixed offset
+        float pixelOffset = offset / pixelDensityMultiplier();
+        // If anchor isn't right the fixed offset is flipped
+        if (anchor != UIxAnchor.Right)
+        {
+            pixelOffset = -pixelOffset;
+        }
+        return pixelOffset;
+    }
 
-	public static float yPercentFrom( UIyAnchor anchor, float percentOffset, float height )
-	{
-		switch( anchor )
-		{
-			case UIyAnchor.Top:
-				return percentOffset * Screen.height;
-			case UIyAnchor.Bottom:
-				return Screen.height - ( percentOffset * Screen.height ) - height;
-		}
-		return 0f;
-	}
+    /// <summary>
+    /// Calculates fixed vertical pixel offset based on SD or HD offset.
+    /// </summary>
+    /// <param name="anchor">Sprite vertical anchor</param>
+    /// <param name="offset">Relative offset</param>
+    /// <returns></returns>
+    public static float yPixelsTo(UIyAnchor anchor, float offset)
+    {
+        // Get initial fixed offset
+        float pixelOffset = offset / pixelDensityMultiplier();
+        // If anchor isn't bottom the fixed offset is flipped
+        if (anchor != UIyAnchor.Bottom)
+        {
+            pixelOffset = -pixelOffset;
+        }
+        return pixelOffset;
+    }
 
+    #endregion
 
-	/// <summary>
-	/// Pixels to offset from the anchor.  If the anchor is bottom, the height will be used to make the offset
-	/// from the bottom-most point of the sprite.
-	/// </summary>
-	public static float yPixelsFrom( UIyAnchor anchor, int pixelOffset )
-	{
-		return yPixelsFrom( anchor, pixelOffset, 0 );
-	}
+    #region Anchor adjustment methods
 
+    /// <summary>
+    /// Finds horizontal adjustment for anchor, based on width and origin of sprite.
+    /// </summary>
+    /// <param name="anchor">Sprite horizontal anchor</param>
+    /// <param name="width">Sprite width</param>
+    /// <param name="originInCenter">True if origin is in center</param>
+    /// <returns></returns>
+    public static float xAnchorAdjustment(UIxAnchor anchor, float width, bool originInCenter)
+    {
+        float adjustment = 0f;
+        switch (anchor)
+        {
+            case UIxAnchor.Left:
+                if (originInCenter)
+                {
+                    adjustment -= width / 2f;
+                }
+                break;
+            case UIxAnchor.Right:
+                if (originInCenter)
+                {
+                    adjustment += width / 2f;
+                }
+                else
+                {
+                    adjustment += width;
+                }
+                break;
+            case UIxAnchor.Center:
+                if (!originInCenter)
+                {
+                    adjustment += width / 2f;
+                }
+                break;
+        }
+        return adjustment;
+    }
 
-	public static float yPixelsFrom( UIyAnchor anchor, int pixelOffset, float height )
-	{
-		switch( anchor )
-		{
-			case UIyAnchor.Top:
-				return pixelOffset * pixelDensityMultiplier();
-			case UIyAnchor.Bottom:
-				return Screen.height - pixelOffset*pixelDensityMultiplier() - height;
-		}
-		return 0f;
-	}
+    /// <summary>
+    /// Finds vertical adjustment for anchor, based on height and origin of sprite.
+    /// </summary>
+    /// <param name="anchor">Sprite vertical anchor</param>
+    /// <param name="height">Sprite height</param>
+    /// <param name="originInCenter">True if origin is in center</param>
+    /// <returns></returns>
+    public static float yAnchorAdjustment(UIyAnchor anchor, float height, bool originInCenter)
+    {
+        float adjustment = 0f;
+        switch (anchor)
+        {
+            case UIyAnchor.Top:
+                if (originInCenter)
+                {
+                    adjustment -= height / 2f;
+                }
+                break;
+            case UIyAnchor.Bottom:
+                if (originInCenter)
+                {
+                    adjustment += height / 2f;
+                }
+                else
+                {
+                    adjustment += height;
+                }
+                break;
+            case UIyAnchor.Center:
+                if (!originInCenter)
+                {
+                    adjustment += height / 2f;
+                }
+                break;
+        }
+        return adjustment;
+    }
 
-
-	public static Vector2 center( float width, float height )
-	{
-		var pos = Vector2.zero;
-		
-		pos.x = Screen.width / 2 - width / 2;
-		pos.y = Screen.height / 2 - height / 2;
-		
-		return pos;
-	}
-
+    #endregion
 }

--- a/Assets/Plugins/UIToolkit/UIAnimation/UIAnimation.cs
+++ b/Assets/Plugins/UIToolkit/UIAnimation/UIAnimation.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 
 
-public enum UIAnimationProperty { Position, LocalScale, EulerAngles, Alpha, Color };
+public enum UIAnimationProperty { Position, Scale, EulerAngles, Alpha, Color };
 
 public class UIAnimation
 {
@@ -119,8 +119,8 @@ public class UIAnimation
 				case UIAnimationProperty.Position:
 					sprite.localPosition = Vector3.Lerp( start, target, easPos );
 					break;
-				case UIAnimationProperty.LocalScale:
-					sprite.localScale = Vector3.Lerp( start, target, easPos );
+				case UIAnimationProperty.Scale:
+					sprite.scale = Vector3.Lerp( start, target, easPos );
 					break;
 				case UIAnimationProperty.EulerAngles:
 					sprite.eulerAngles = Vector3.Lerp( start, target, easPos );
@@ -143,10 +143,19 @@ public class UIAnimation
 				{
 					autoreverse = false; // make sure this only happens once!
 					
-					// flip our start and target and reset the start time
+					// flip our start and target
 					var temp = start;
 					start = target;
 					target = temp;
+                    // flip alpha variables
+                    var tempFloat = startFloat;
+                    startFloat = targetFloat;
+                    targetFloat = tempFloat;
+                    // flip color variables
+                    var tempColor = startColor;
+                    startColor = targetColor;
+                    targetColor = tempColor;
+                    // reset the start time
 					startTime = Time.time;
 				}
 				else
@@ -198,8 +207,8 @@ public class UIAnimation
 			case UIAnimationProperty.Position:
 				start = sprite.localPosition;
 				break;
-			case UIAnimationProperty.LocalScale:
-				start = sprite.localScale;
+			case UIAnimationProperty.Scale:
+				start = sprite.scale;
 				break;
 			case UIAnimationProperty.EulerAngles:
 				start = sprite.eulerAngles;
@@ -236,7 +245,7 @@ public class UIAnimation
 		switch( _aniProperty )
 		{
 			case UIAnimationProperty.Position:
-			case UIAnimationProperty.LocalScale:
+			case UIAnimationProperty.Scale:
 			case UIAnimationProperty.EulerAngles:
 				target = newTarget;
 				break;

--- a/Assets/Plugins/UIToolkit/UIElements/UIText.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UIText.cs
@@ -585,7 +585,7 @@ public class UIText : System.Object
 	public void updateText( UITextInstance textInstance )
 	{
 		// kill the current text then draw some new text
-		drawText( textInstance, textInstance.xPos, textInstance.yPos, textInstance.scale, textInstance.depth, textInstance.colors, textInstance.alignMode, textInstance.verticalAlignMode );
+		drawText( textInstance, textInstance.xPos, textInstance.yPos, textInstance.textScale, textInstance.depth, textInstance.colors, textInstance.alignMode, textInstance.verticalAlignMode );
 	}
 	
 	

--- a/Assets/Plugins/UIToolkit/UIElements/UITextInstance.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UITextInstance.cs
@@ -5,16 +5,20 @@ using System.Collections.Generic;
 
 
 // addTextInstance (from the UIText class) returns one of these so we just need to do a .text on the instance to update it's text
-public class UITextInstance : UIObject
+public class UITextInstance : UIObject, IPositionable
 {
 	private UIText _parentText;
 	private string _text;
+    private float _scale;
 	public UITextAlignMode alignMode;
 	public UITextVerticalAlignMode verticalAlignMode;
-	
+
+    private float _width;
+    public new float width { get { return _width; } }
+    private float _height;
+    public new float height { get { return _height; } }
 	public float xPos;
 	public float yPos;
-	public float scale;
 	public int depth;
 	public Color[] colors;
 	public List<UISprite> textSprites = new List<UISprite>(); // all the sprites that make up the string
@@ -33,7 +37,7 @@ public class UITextInstance : UIObject
 			_text = value;
 			
 			// cleanse our textSprites of any excess that we dont need
-			if( _text.Length < textSprites.Count )
+			if( _text.Length > textSprites.Count )
 			{
 				for( var i = textSprites.Count - 1; i > _text.Length; i-- )
 				{
@@ -44,8 +48,23 @@ public class UITextInstance : UIObject
 			}
 			
 			_parentText.updateText( this );
+            updateSize();
 		}
 	}
+
+    public float textScale
+    {
+        get { return _scale; }
+        set
+        {
+            // Don't do anything if scale is the same
+            if (_scale == value) return;
+
+            _scale = value;
+            _parentText.updateText(this);
+            updateSize();
+        }
+    }
 	
 	private bool _hidden;
 	public bool hidden 
@@ -83,14 +102,21 @@ public class UITextInstance : UIObject
 		this.verticalAlignMode = verticalAlignMode;
 		_parentText = parentText;
 		_text = text;
+        _scale = scale;
 		this.xPos = xPos;
 		this.yPos = yPos;
-		this.scale = scale;
 		this.depth = depth;
 		this.colors = colors;
 		_hidden = false;
+        updateSize();
 	}
-	
+
+    private void updateSize()
+    {
+        Vector2 size = _parentText.sizeForText(_text, _scale);
+        _width = size.x;
+        _height = size.y;
+    }
 	
 	private void applyColorToSprites()
 	{
@@ -171,5 +197,5 @@ public class UITextInstance : UIObject
 	{
 		
 	}
-
+    
 }

--- a/Assets/Plugins/UIToolkit/UIElements/UITextInstance.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UITextInstance.cs
@@ -37,7 +37,7 @@ public class UITextInstance : UIObject, IPositionable
 			_text = value;
 			
 			// cleanse our textSprites of any excess that we dont need
-			if( _text.Length > textSprites.Count )
+			if( _text.Length < textSprites.Count )
 			{
 				for( var i = textSprites.Count - 1; i > _text.Length; i-- )
 				{

--- a/Assets/Plugins/UIToolkit/UIElements/UIZoomButton.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UIZoomButton.cs
@@ -59,8 +59,8 @@ public class UIZoomButton : UIButton
 	public UIZoomButton( UIToolkit manager, Rect frame, int depth, UIUVRect uvFrame, UIUVRect highlightedUVframe ):base( manager, frame, depth, uvFrame, highlightedUVframe )
 	{
 		centerize();
-		_zoomInAnimation = new UIAnimation( this, 0.3f, UIAnimationProperty.LocalScale, new Vector3( 1, 1, 1 ), new Vector3( 1.3f, 1.3f, 1.3f ), Easing.Quartic.easeInOut );
-		_zoomOutAnimation = new UIAnimation( this, 0.3f, UIAnimationProperty.LocalScale, new Vector3( 1.3f, 1.3f, 1.3f ), new Vector3( 1, 1, 1 ), Easing.Quartic.easeInOut );
+		_zoomInAnimation = new UIAnimation( this, 0.3f, UIAnimationProperty.Scale, new Vector3( 1, 1, 1 ), new Vector3( 1.3f, 1.3f, 1.3f ), Easing.Quartic.easeInOut );
+		_zoomOutAnimation = new UIAnimation( this, 0.3f, UIAnimationProperty.Scale, new Vector3( 1.3f, 1.3f, 1.3f ), new Vector3( 1, 1, 1 ), Easing.Quartic.easeInOut );
 	}
 
 	#endregion;


### PR DESCRIPTION
Changes to UIObject, IPositionable and UISprite was needed to make this possible.
Option to auto refresh position when scaling an object.
Auto adjustment of anchoring when parent changes is implemented.
Centerizing a sprite is taken into account when positioning.
Removed positionCenterX and positionCenterY from position extensions as they no longer made sense in regards to the newly introduced methods.
