### PR TITLE
Correction for relative positioning and anchoring

### DIFF
--- a/Assets/Plugins/UIToolkit/Support/IPositionablePositioningExtensions.cs
+++ b/Assets/Plugins/UIToolkit/Support/IPositionablePositioningExtensions.cs
@@ -129,6 +129,8 @@ public static class IPositionablePositioningExtensions
         // Set new anchor information
         sprite.anchorInfo = anchorInfo;
 
+				Debug.Log(sprite.anchorInfo);
+
         // Refresh position
         sprite.refreshPosition();
     }
@@ -875,13 +877,14 @@ public static class IPositionablePositioningExtensions
         UIAnchorInfo anchorInfo = sprite.anchorInfo;
 
         // Get parent anchor position
-        Vector3 position = parentAnchorPosition(anchorInfo.ParentUIObject, anchorInfo.ParentUIyAnchor, anchorInfo.ParentUIxAnchor);
+				Vector3 position = parentAnchorPosition(anchorInfo.ParentUIObject, anchorInfo.ParentUIyAnchor, anchorInfo.ParentUIxAnchor);
+
 
         // Add position offset
         if (anchorInfo.UIPrecision == UIPrecision.Percentage)
         {
-            position.x += UIRelative.xPercentFrom(anchorInfo.UIxAnchor, anchorInfo.OffsetX);
-            position.y -= UIRelative.yPercentFrom(anchorInfo.UIyAnchor, anchorInfo.OffsetY);
+						position.x += xPercentFromParent(anchorInfo.ParentUIObject,anchorInfo.UIxAnchor, anchorInfo.OffsetX);
+						position.y -= yPercentFromParent(anchorInfo.ParentUIObject, anchorInfo.UIyAnchor, anchorInfo.OffsetY);
         }
         else
         {
@@ -930,5 +933,56 @@ public static class IPositionablePositioningExtensions
 
         return position;
     }
+
+    /// <summary>
+    /// Returns width of parent or screen if parent is null
+    /// </summary>
+    /// <param name="sprite">Provided parent</param>
+    /// <returns>Width of parent (or screen)</returns>
+		private static float parentWidth(IPositionable sprite) {
+			return (sprite == null) ? Screen.width : sprite.width;
+		}
+
+		/// <summary>
+		/// Returns height of parent or screen if parent is null
+		/// </summary>
+		/// <param name="sprite">Provided parent</param>
+		/// <returns>Height of parent (or screen)</returns>
+		private static float parentHeight(IPositionable sprite)
+		{
+			return (sprite == null) ? Screen.height : sprite.height;
+		}
+
+		/// <summary>
+		/// Calculates relative offset based on parent sprite width percentage.
+		/// </summary>
+		/// <param name="sprite">Provided parent (or null for screen)</param>
+		/// <param name="anchor">Sprite horizontal anchor</param>
+		/// <param name="percentOffset">Percentage offset - 1 is 100%</param>
+		/// <returns></returns>
+		private static float xPercentFromParent(IPositionable sprite, UIxAnchor anchor, float percentOffset)
+		{
+			if (percentOffset == 0)
+				return 0;
+			float offset = parentWidth(sprite) * percentOffset;
+			return (anchor == UIxAnchor.Right) ? -offset : offset;
+
+		}
+
+		/// <summary>
+		/// Calculates relative offset based on parent sprite height percentage.
+		/// </summary>
+		/// <param name="sprite">Provided parent (or null for screen)</param>
+		/// <param name="anchor">Sprite vertical anchor</param>
+		/// <param name="percentOffset">Percentage offset - 1 is 100%</param>
+		/// <returns></returns>
+		private static float yPercentFromParent(IPositionable sprite, UIyAnchor anchor, float percentOffset)
+		{
+			if (percentOffset == 0)
+				return 0;
+			float offset = parentHeight(sprite) * percentOffset;
+			return (anchor == UIyAnchor.Bottom) ? -offset : offset;
+
+		}
 
 }


### PR DESCRIPTION
Since the refactor of positioning... anchoring and relative positioning has been broken for the right and bottom.

For example: 

``` C#
sprite.positionFromBottomRight(0,0);
```

Would move the sprite too far and not be visible at all on screen; where one expects it to be visible and anchored to the bottom right of the screen.

None of the demo scenes that use any right/bottom positioning are working correctly.

This commit fixes this problem by reworking the logic in IPositionablePositioningExtensions.cs : refreshPosition().

Notes:
- This also introduces what I believe to be the expected behavior that if you are positioning a sprite relative to a parent, then the percentages are relative to the parent as well.  For example, if I position to the bottom left but with 25% offset, it would move 25% the width of its parent.  Originally it was the screen, which didn't seem to make any sense or be useable for anything in this context.  Pixel offsets still work the same as they are absolute.
- There may be other issues with parenting propagation elsewhere in the code when it comes to animation, for example.  I've not looked into this, nor tested this as its unrelated parts of the code.  My thinking is that if this was wrong, other things might be wrong too.
- All the demo scenes now work correct as far as relative positioning goes.  However Kitchen Sink still has an error on startup which seems related to the original refactoring but is an entirely different bug not related to this code change.
- Even though this code works, the choice of where I put my support methods may not match the intended pattern as it relates to, say, the UIRelative class.  Too keep it simple and obvious I did all my work in one file, so this might need some methods moved around for architectural purposes.
