### PR TITLE
bug fix: fix very quick, non selecting touches on buttons, which used…

### DIFF
--- a/Assets/Plugins/UIToolkit/UIToolkit.cs
+++ b/Assets/Plugins/UIToolkit/UIToolkit.cs
@@ -253,6 +253,13 @@ public class UIToolkit : UISpriteManager
 				// Deselect the touched sprite
 				_spriteSelected[touch.fingerId] = null;
 			}
+			else if(_spriteSelected[touch.fingerId] != null)
+			{
+				// If we have a button that isn't the selected button end the touch on it because we moved off of it
+				// quickly enough that we never got a TouchPhase.Moved or TouchPhase.Stationary
+				_spriteSelected[touch.fingerId].onTouchEnded( touch, fixedTouchPosition, false );
+				_spriteSelected[touch.fingerId] = null;
+			}			
 		}
 	}
 


### PR DESCRIPTION
… to leave buttons in their highlighted state

if we touch and release a button quickly enough you can have begin and end touch phases without a moved or stationary phase. this was handled if the end of the touch was inside the buttons area, but not if it was outside
