### PR TITLE
Fixes null ref when unparenting a control

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
@@ -181,6 +181,8 @@ public class UIObject : System.Object, IPositionable
 			if( _parentUIObject != null )
 			{
 				clientTransform.parent = _parentUIObject.clientTransform;
+				// add the new listener
+				_parentUIObject.onTransformChanged += transformChanged;
 			}
 			else
 			{
@@ -188,10 +190,7 @@ public class UIObject : System.Object, IPositionable
 					clientTransform.parent = ((UISprite)this).manager.transform;
 				else
 					clientTransform.parent = null;
-			}
-			
-			// add the new listener
-			_parentUIObject.onTransformChanged += transformChanged;
+			}			
 		}
 	}
 	


### PR DESCRIPTION
Moved a small bit of code so that it would not null ref when unparenting.
