### PR TITLE
Trimsupport Step 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Library/ScriptAssemblies/*
 
 Assembly-CSharp-*
 UIToolkit-csharp.sln
+*.suo

--- a/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
@@ -22,27 +22,27 @@ public struct UITextureInfo
 }
 
 
-public class UISpriteManager : MonoBehaviour 
+public class UISpriteManager : MonoBehaviour
 {
 	#region ivars
-	
+
 	public enum UISpriteWindowOrder
 	{
-	    CCW,
-	    CW
+		CCW,
+		CW
 	};
-	
+
 	public string texturePackerConfigName;
 	public Material material;
 	public int layer;
-	
+
 	protected bool meshIsDirty = false; // Flag that gets set if any of the following flags are set.  No updates will happen unless this is true
 	protected bool vertsChanged = false;    // Have changes been made to the vertices of the mesh since the last frame?
 	protected bool uvsChanged = false;    // Have changes been made to the UVs of the mesh since the last frame?
 	protected bool colorsChanged = false;   // Have the colors changed?
 	protected bool vertCountChanged = false;// Has the number of vertices changed?
 	protected bool updateBounds = false;    // Update the mesh bounds?
-	
+
 	private UISprite[] _sprites = new UISprite[0];    // Array of all sprites (the offset of the vertices corresponding to each sprite should be found simply by taking the sprite's index * 4 (4 verts per sprite).
 	private UISpriteWindowOrder winding = UISpriteWindowOrder.CCW; // Which way to wind polygons
 	private MeshFilter _meshFilter;
@@ -50,85 +50,84 @@ public class UISpriteManager : MonoBehaviour
 	private Mesh _mesh;
 	[HideInInspector]
 	public Vector2 textureSize = Vector2.zero;
-	
+
 	protected Vector3[] vertices = new Vector3[0];  // The vertices of our mesh
 	protected int[] triIndices = new int[0];    // Indices into the vertex array
 	protected Vector2[] UVs = new Vector2[0];       // UV coordinates
 	protected Color[] colors = new Color[0];      // Color values
-	
+
 	protected Dictionary<string, UITextureInfo> textureDetails; // texture details loaded from the TexturePacker config file
 
 	#endregion;
-	
+
 
 	#region MonoBehaviour Functions
 
-    virtual protected void Awake()
-    {
-        _meshFilter = gameObject.AddComponent<MeshFilter>();
-        _meshRenderer = gameObject.AddComponent<MeshRenderer>();
+	virtual protected void Awake()
+	{
+		_meshFilter = gameObject.AddComponent<MeshFilter>();
+		_meshRenderer = gameObject.AddComponent<MeshRenderer>();
 
-        _meshRenderer.renderer.material = material;
-        _mesh = _meshFilter.mesh;
+		_meshRenderer.renderer.material = material;
+		_mesh = _meshFilter.mesh;
 
-        // Move the object to the origin so the objects drawn will not be offset from the objects they are intended to represent.
-        // Offset on z axis according to the specified layer
-        transform.position = new Vector3( 0, 0, layer );
-        transform.rotation = Quaternion.identity;
-    }
-	
+		// Move the object to the origin so the objects drawn will not be offset from the objects they are intended to represent.
+		// Offset on z axis according to the specified layer
+		transform.position = new Vector3(0, 0, layer);
+		transform.rotation = Quaternion.identity;
+	}
+
 	#endregion;
-	
-	
+
+
 	#region Texture management
-	
+
 	public void loadTextureAndPrepareForUse()
 	{
 		// load our texture, at 2x if necessary
-		if( UI.instance.isHD )
+		if (UI.instance.isHD)
 			texturePackerConfigName = texturePackerConfigName + UI.instance.hdExtension;
-		
-		var texture = (Texture)Resources.Load( texturePackerConfigName, typeof( Texture ) );
-		if( texture == null )
-			Debug.Log( "UI texture is being autoloaded and it doesnt exist.  Cannot find texturePackerConfigName: " + texturePackerConfigName );
-		material.SetTexture( "_MainTex", texture );
-		
+
+		var texture = (Texture)Resources.Load(texturePackerConfigName, typeof(Texture));
+		if (texture == null)
+			Debug.Log("UI texture is being autoloaded and it doesnt exist.  Cannot find texturePackerConfigName: " + texturePackerConfigName);
+		material.SetTexture("_MainTex", texture);
+
 		// Cache our texture size
-		Texture t = material.GetTexture( "_MainTex" );
-		textureSize = new Vector2( t.width, t.height );
-		
+		Texture t = material.GetTexture("_MainTex");
+		textureSize = new Vector2(t.width, t.height);
+
 		// load up the config file
-		textureDetails = loadTexturesFromTexturePackerJSON( texturePackerConfigName );
+		textureDetails = loadTexturesFromTexturePackerJSON(texturePackerConfigName);
 	}
 
-	
-	private Dictionary<string, UITextureInfo> loadTexturesFromTexturePackerJSON( string filename )
+
+	private Dictionary<string, UITextureInfo> loadTexturesFromTexturePackerJSON(string filename)
 	{
 		var textures = new Dictionary<string, UITextureInfo>();
-		
-		var asset = Resources.Load( filename, typeof( TextAsset ) ) as TextAsset;		
-		if( asset == null )
-			Debug.LogError( "Could not find Texture Packer json config file in Resources folder: " + filename );
+
+		var asset = Resources.Load(filename, typeof(TextAsset)) as TextAsset;
+		if (asset == null)
+			Debug.LogError("Could not find Texture Packer json config file in Resources folder: " + filename);
 
 		var jsonString = asset.text;
 		var decodedHash = jsonString.hashtableFromJson();
 		var frames = (Hashtable)decodedHash["frames"];
-	
-		foreach( System.Collections.DictionaryEntry item in frames )
-		{
+
+		foreach (System.Collections.DictionaryEntry item in frames) {
 			// extract the info we need from the TexturePacker json file, mainly uvRect and size
 			var frame = (Hashtable)((Hashtable)item.Value)["frame"];
-			var frameX = int.Parse( frame["x"].ToString() );
-			var frameY = int.Parse( frame["y"].ToString() );
-			var frameW = int.Parse( frame["w"].ToString() );
-			var frameH = int.Parse( frame["h"].ToString() );
-		
+			var frameX = int.Parse(frame["x"].ToString());
+			var frameY = int.Parse(frame["y"].ToString());
+			var frameW = int.Parse(frame["w"].ToString());
+			var frameH = int.Parse(frame["h"].ToString());
+
 			// for trimming support
 			var spriteSourceSize = (Hashtable)((Hashtable)item.Value)["spriteSourceSize"];
-			var spriteSourceSizeX = int.Parse( spriteSourceSize["x"].ToString() );
-			var spriteSourceSizeY = int.Parse( spriteSourceSize["y"].ToString() );
-			var spriteSourceSizeW = int.Parse( spriteSourceSize["w"].ToString() );
-			var spriteSourceSizeH = int.Parse( spriteSourceSize["h"].ToString() );
+			var spriteSourceSizeX = int.Parse(spriteSourceSize["x"].ToString());
+			var spriteSourceSizeY = int.Parse(spriteSourceSize["y"].ToString());
+			var spriteSourceSizeW = int.Parse(spriteSourceSize["w"].ToString());
+			var spriteSourceSizeH = int.Parse(spriteSourceSize["h"].ToString());
 
 			var sourceSize = (Hashtable)((Hashtable)item.Value)["sourceSize"];
 			var sourceSizeX = int.Parse(sourceSize["w"].ToString());
@@ -136,370 +135,360 @@ public class UISpriteManager : MonoBehaviour
 
 			var trimmed = (bool)((Hashtable)item.Value)["trimmed"];
 			var rotated = (bool)((Hashtable)item.Value)["rotated"];
-			
+
 			var ti = new UITextureInfo();
-			ti.frame = new Rect( frameX, frameY, frameW, frameH );
-			ti.uvRect = new UIUVRect( frameX, frameY, frameW, frameH, textureSize );
-			ti.spriteSourceSize = new Rect( spriteSourceSizeX, spriteSourceSizeY, spriteSourceSizeW, spriteSourceSizeH );
+			ti.frame = new Rect(frameX, frameY, frameW, frameH);
+			ti.uvRect = new UIUVRect(frameX, frameY, frameW, frameH, textureSize);
+			ti.spriteSourceSize = new Rect(spriteSourceSizeX, spriteSourceSizeY, spriteSourceSizeW, spriteSourceSizeH);
 			ti.sourceSize = new Vector2(sourceSizeX, sourceSizeY);
 			ti.trimmed = trimmed;
 			ti.rotated = rotated;
-			
-			textures.Add( item.Key.ToString(), ti );
+
+			textures.Add(item.Key.ToString(), ti);
 		}
-		
+
 		// unload the asset
 		asset = null;
-		Resources.UnloadUnusedAssets();	
-		
+		Resources.UnloadUnusedAssets();
+
 		return textures;
 	}
-	
-	
+
+
 	/// <summary>
 	/// grabs the UITextureInfo for the given filename
 	/// </summary>
-	public UITextureInfo textureInfoForFilename( string filename )
+	public UITextureInfo textureInfoForFilename(string filename)
 	{
 #if UNITY_EDITOR
 		// sanity check while in editor
-		if( !textureDetails.ContainsKey( filename ) )
-			throw new Exception( "can't find texture details for texture packer sprite:" + filename );
+		if (!textureDetails.ContainsKey(filename))
+			throw new Exception("can't find texture details for texture packer sprite:" + filename);
 #endif
 		return textureDetails[filename];
 	}
-	
-	
+
+
 	/// <summary>
 	/// grabs the uvRect for the given filename
 	/// </summary>
-	public UIUVRect uvRectForFilename( string filename )
+	public UIUVRect uvRectForFilename(string filename)
 	{
 #if UNITY_EDITOR
 		// sanity check while in editor
-		if( !textureDetails.ContainsKey( filename ) )
-			throw new Exception( "can't find texture details for texture packer sprite:" + filename );
+		if (!textureDetails.ContainsKey(filename))
+			throw new Exception("can't find texture details for texture packer sprite:" + filename);
 #endif
 		return textureDetails[filename].uvRect;
 	}
-		
-		
+
+
 	/// <summary>
 	/// grabs the frame for the given filename
 	/// </summary>
-	public Rect frameForFilename( string filename )
+	public Rect frameForFilename(string filename)
 	{
 #if UNITY_EDITOR
 		// sanity check while in editor
-		if( !textureDetails.ContainsKey( filename ) )
-			throw new Exception( "can't find texture details for texture packer sprite:" + filename );
+		if (!textureDetails.ContainsKey(filename))
+			throw new Exception("can't find texture details for texture packer sprite:" + filename);
 #endif
 		return textureDetails[filename].frame;
 	}
 
-	
+
 	#endregion
-	
-	
+
+
 	#region Vertex and UV array management
 
 	/// <summary>
 	/// Enlarges the sprite array by the specified count and also resizes the UV and vertex arrays by the necessary corresponding amount.
 	/// Returns the index of the first newly allocated element
 	/// </summary>
-    protected int expandMaxSpriteLimit( int count )
-    {
-        int firstNewElement = _sprites.Length;
+	protected int expandMaxSpriteLimit(int count)
+	{
+		int firstNewElement = _sprites.Length;
 
-        // Resize sprite array:
-        UISprite[] tempSprites = _sprites;
-        _sprites = new UISprite[_sprites.Length + count];
-        tempSprites.CopyTo( _sprites, 0 );
+		// Resize sprite array:
+		UISprite[] tempSprites = _sprites;
+		_sprites = new UISprite[_sprites.Length + count];
+		tempSprites.CopyTo(_sprites, 0);
 
-        // Vertices:
-        Vector3[] tempVerts = vertices;
-        vertices = new Vector3[vertices.Length + count * 4];
-        tempVerts.CopyTo( vertices, 0 );
-        
-        // UVs:
-        Vector2[] tempUVs = UVs;
-        UVs = new Vector2[UVs.Length + count * 4];
-        tempUVs.CopyTo( UVs, 0 );
+		// Vertices:
+		Vector3[] tempVerts = vertices;
+		vertices = new Vector3[vertices.Length + count * 4];
+		tempVerts.CopyTo(vertices, 0);
 
-        // Colors:
-        Color[] tempColors = colors;
-        colors = new Color[colors.Length + count * 4];
-        tempColors.CopyTo( colors, 0 );
+		// UVs:
+		Vector2[] tempUVs = UVs;
+		UVs = new Vector2[UVs.Length + count * 4];
+		tempUVs.CopyTo(UVs, 0);
 
-        // Triangle indices:
-        int[] tempTris = triIndices;
-        triIndices = new int[triIndices.Length + count * 6];
-        tempTris.CopyTo( triIndices, 0 );
+		// Colors:
+		Color[] tempColors = colors;
+		colors = new Color[colors.Length + count * 4];
+		tempColors.CopyTo(colors, 0);
 
-        // Inform existing sprites of the new vertex and UV buffers:
-        for( int i = 0; i < firstNewElement; ++i )
-            _sprites[i].setBuffers( vertices, UVs );
+		// Triangle indices:
+		int[] tempTris = triIndices;
+		triIndices = new int[triIndices.Length + count * 6];
+		tempTris.CopyTo(triIndices, 0);
 
-        // Setup the newly-added sprites and Add them to the list of available 
-        // sprite blocks. Also initialize the triangle indices while we're at it:
-        for( int i = firstNewElement; i < _sprites.Length; ++i )
-        {
-            // Init triangle indices:
-            if( winding == UISpriteWindowOrder.CCW )
-            {   // Counter-clockwise winding
-                triIndices[i * 6 + 0] = i * 4 + 0;  //    0_ 2            0 ___ 3
-                triIndices[i * 6 + 1] = i * 4 + 1;  //  | /      Verts:  |   /|
-                triIndices[i * 6 + 2] = i * 4 + 3;  // 1|/                1|/__|2
+		// Inform existing sprites of the new vertex and UV buffers:
+		for (int i = 0; i < firstNewElement; ++i)
+			_sprites[i].setBuffers(vertices, UVs);
 
-                triIndices[i * 6 + 3] = i * 4 + 3;  //      3
-                triIndices[i * 6 + 4] = i * 4 + 1;  //   /|
-                triIndices[i * 6 + 5] = i * 4 + 2;  // 4/_|5
-            }
-            else
-            {   // Clockwise winding
-                triIndices[i * 6 + 0] = i * 4 + 0;  //    0_ 1            0 ___ 3
-                triIndices[i * 6 + 1] = i * 4 + 3;  //  | /      Verts:  |   /|
-                triIndices[i * 6 + 2] = i * 4 + 1;  // 2|/                1|/__|2
+		// Setup the newly-added sprites and Add them to the list of available 
+		// sprite blocks. Also initialize the triangle indices while we're at it:
+		for (int i = firstNewElement; i < _sprites.Length; ++i) {
+			// Init triangle indices:
+			if (winding == UISpriteWindowOrder.CCW) {   // Counter-clockwise winding
+				triIndices[i * 6 + 0] = i * 4 + 0;  //    0_ 2            0 ___ 3
+				triIndices[i * 6 + 1] = i * 4 + 1;  //  | /      Verts:  |   /|
+				triIndices[i * 6 + 2] = i * 4 + 3;  // 1|/                1|/__|2
 
-                triIndices[i * 6 + 3] = i * 4 + 3;  //      3
-                triIndices[i * 6 + 4] = i * 4 + 2;  //   /|
-                triIndices[i * 6 + 5] = i * 4 + 1;  // 5/_|4
-            }
-        }
+				triIndices[i * 6 + 3] = i * 4 + 3;  //      3
+				triIndices[i * 6 + 4] = i * 4 + 1;  //   /|
+				triIndices[i * 6 + 5] = i * 4 + 2;  // 4/_|5
+			}
+			else {   // Clockwise winding
+				triIndices[i * 6 + 0] = i * 4 + 0;  //    0_ 1            0 ___ 3
+				triIndices[i * 6 + 1] = i * 4 + 3;  //  | /      Verts:  |   /|
+				triIndices[i * 6 + 2] = i * 4 + 1;  // 2|/                1|/__|2
 
-        vertsChanged = true;
-        uvsChanged = true;
-        colorsChanged = true;
-        vertCountChanged = true;
+				triIndices[i * 6 + 3] = i * 4 + 3;  //      3
+				triIndices[i * 6 + 4] = i * 4 + 2;  //   /|
+				triIndices[i * 6 + 5] = i * 4 + 1;  // 5/_|4
+			}
+		}
+
+		vertsChanged = true;
+		uvsChanged = true;
+		colorsChanged = true;
+		vertCountChanged = true;
 		meshIsDirty = true;
 
-        return firstNewElement;
-    }
-	
+		return firstNewElement;
+	}
+
 
 	/// <summary>
 	/// Performs any changes if the verts, UVs, colors or bounds changed
 	/// </summary>
 	protected void updateMeshProperties()
 	{
-        // Were changes made to the mesh since last time?
-        if( vertCountChanged )
-        {
-            vertCountChanged = false;
-            colorsChanged = false;
-            vertsChanged = false;
-            uvsChanged = false;
-            updateBounds = false;
+		// Were changes made to the mesh since last time?
+		if (vertCountChanged) {
+			vertCountChanged = false;
+			colorsChanged = false;
+			vertsChanged = false;
+			uvsChanged = false;
+			updateBounds = false;
 
-            _mesh.Clear();
-            _mesh.vertices = vertices;
-            _mesh.uv = UVs;
-            _mesh.colors = colors;
-            _mesh.triangles = triIndices;
-        }
-        else
-        {
-            if( vertsChanged )
-            {
-                vertsChanged = false;
-                updateBounds = true;
+			_mesh.Clear();
+			_mesh.vertices = vertices;
+			_mesh.uv = UVs;
+			_mesh.colors = colors;
+			_mesh.triangles = triIndices;
+		}
+		else {
+			if (vertsChanged) {
+				vertsChanged = false;
+				updateBounds = true;
 
-                _mesh.vertices = vertices;
-            }
+				_mesh.vertices = vertices;
+			}
 
-            if( updateBounds )
-            {
-                _mesh.RecalculateBounds();
-                updateBounds = false;
-            }
+			if (updateBounds) {
+				_mesh.RecalculateBounds();
+				updateBounds = false;
+			}
 
-            if( colorsChanged )
-            {
-                colorsChanged = false;
-                _mesh.colors = colors;
-            }
+			if (colorsChanged) {
+				colorsChanged = false;
+				_mesh.colors = colors;
+			}
 
-            if( uvsChanged )
-            {
-                uvsChanged = false;
-                _mesh.uv = UVs;
-            }
-        } // end else
+			if (uvsChanged) {
+				uvsChanged = false;
+				_mesh.uv = UVs;
+			}
+		} // end else
 	}
-	
+
 	#endregion
-	
+
 
 	#region Add/Remove sprite functions
-	
+
 	/// <summary>
 	/// Adds a new sprite to the mix at the given position
 	/// </summary>
-	public UISprite addSprite( string name, int xPos, int yPos )
+	public UISprite addSprite(string name, int xPos, int yPos)
 	{
-		return addSprite( name, xPos, yPos, 1, false );
-	}
-	
-	
-	public UISprite addSprite( string name, int xPos, int yPos, int depth )
-	{
-		return addSprite( name, xPos, yPos, depth, false );
+		return addSprite(name, xPos, yPos, 1, false);
 	}
 
-	
-    public UISprite addSprite( string name, int xPos, int yPos, int depth, bool gameObjectOriginInCenter )
-    {
+
+	public UISprite addSprite(string name, int xPos, int yPos, int depth)
+	{
+		return addSprite(name, xPos, yPos, depth, false);
+	}
+
+
+	public UISprite addSprite(string name, int xPos, int yPos, int depth, bool gameObjectOriginInCenter)
+	{
 #if UNITY_EDITOR
 		// sanity check while in editor
-		if( !textureDetails.ContainsKey( name ) )
-			throw new Exception( "can't find texture details for texture packer sprite:" + name );
+		if (!textureDetails.ContainsKey(name))
+			throw new Exception("can't find texture details for texture packer sprite:" + name);
 #endif
 		var textureInfo = textureDetails[name];
-		var positionRect = new Rect( xPos, yPos, textureInfo.frame.width, textureInfo.frame.height );
+		var positionRect = new Rect(xPos, yPos, textureInfo.frame.width, textureInfo.frame.height);
 
-		return this.addSprite( positionRect, textureInfo.uvRect, depth, gameObjectOriginInCenter );
-    }
+		return this.addSprite(positionRect, textureInfo.uvRect, depth, gameObjectOriginInCenter);
+	}
 
-	
+
 	/// <summary>
 	/// Shortcut for adding a new sprite using the raw materials
 	/// </summary>
-    private UISprite addSprite( Rect frame, UIUVRect uvFrame, int depth, bool gameObjectOriginInCenter )
-    {
-        // Create and initialize the new sprite
-		UISprite newSprite = new UISprite( frame, depth, uvFrame, gameObjectOriginInCenter );
-		addSprite( newSprite );
-		
-		return newSprite;
-    }
+	private UISprite addSprite(Rect frame, UIUVRect uvFrame, int depth, bool gameObjectOriginInCenter)
+	{
+		// Create and initialize the new sprite
+		UISprite newSprite = new UISprite(frame, depth, uvFrame, gameObjectOriginInCenter);
+		addSprite(newSprite);
 
-	
-    /// <summary>
+		return newSprite;
+	}
+
+
+	/// <summary>
 	/// Adds a sprite to the manager
 	/// </summary>
-    public void addSprite( UISprite sprite )
-    {
-        // Initialize the new sprite and update the UVs		
+	public void addSprite(UISprite sprite)
+	{
+		// Initialize the new sprite and update the UVs		
 		int i = 0;
-	
+
 		// Find the first available sprite index
-		for( ; i < _sprites.Length; i++ )
-		{
-			if( _sprites[i] == null )
+		for (; i < _sprites.Length; i++) {
+			if (_sprites[i] == null)
 				break;
 		}
-		
-		// did we find a sprite?  if not, expand our arrays
-		if( i == _sprites.Length )
-			i = expandMaxSpriteLimit( 5 );
-		
-        // Assign and setup the sprite
-		_sprites[i] = sprite;
-		
-        sprite.index = i;
-        sprite.manager = this as UIToolkit;
-        sprite.parent = transform;
 
-        sprite.setBuffers( vertices, UVs );
+		// did we find a sprite?  if not, expand our arrays
+		if (i == _sprites.Length)
+			i = expandMaxSpriteLimit(5);
+
+		// Assign and setup the sprite
+		_sprites[i] = sprite;
+
+		sprite.index = i;
+		sprite.manager = this as UIToolkit;
+		sprite.parent = transform;
+
+		sprite.setBuffers(vertices, UVs);
 
 		// Setup indices of the sprites vertices, UV entries and color values
-		sprite.vertexIndices.initializeVertsWithIndex( i );
+		sprite.vertexIndices.initializeVertsWithIndex(i);
 		sprite.initializeSize();
 		sprite.color = Color.white;
-		
-        // Set our flags to trigger a mesh update
-        vertsChanged = true;
-        uvsChanged = true;
+
+		// Set our flags to trigger a mesh update
+		vertsChanged = true;
+		uvsChanged = true;
 		meshIsDirty = true;
-    }
+	}
 
 
-    protected void removeSprite( UISprite sprite )
-    {
+	protected void removeSprite(UISprite sprite)
+	{
 		vertices[sprite.vertexIndices.mv.one] = Vector3.zero;
 		vertices[sprite.vertexIndices.mv.two] = Vector3.zero;
 		vertices[sprite.vertexIndices.mv.three] = Vector3.zero;
 		vertices[sprite.vertexIndices.mv.four] = Vector3.zero;
 
-        _sprites[sprite.index] = null;
+		_sprites[sprite.index] = null;
 
-        // remove any delegate callbacks, etc.
-        sprite.parentUIObject = null;
-		
+		// remove any delegate callbacks, etc.
+		sprite.parentUIObject = null;
+
 		// This should happen when the sprite dies!!
-		Destroy( sprite.client );
+		Destroy(sprite.client);
 
-        vertsChanged = true;
+		vertsChanged = true;
 		meshIsDirty = true;
-    }
+	}
 
 	#endregion;
-	
-	
+
+
 	#region Show/Hide sprite functions
 
-    public void hideSprite( UISprite sprite )
-    {
-        sprite.___hidden = true;
+	public void hideSprite(UISprite sprite)
+	{
+		sprite.___hidden = true;
 
 		vertices[sprite.vertexIndices.mv.one] = Vector3.zero;
 		vertices[sprite.vertexIndices.mv.two] = Vector3.zero;
 		vertices[sprite.vertexIndices.mv.three] = Vector3.zero;
 		vertices[sprite.vertexIndices.mv.four] = Vector3.zero;
 
-        vertsChanged = true;
+		vertsChanged = true;
 		meshIsDirty = true;
-    }
+	}
 
-	
-    public void showSprite( UISprite sprite )
-    {
-        if( !sprite.___hidden )
-            return;
 
-        sprite.___hidden = false;
+	public void showSprite(UISprite sprite)
+	{
+		if (!sprite.___hidden)
+			return;
 
-        // Update the vertices.  This will end up caling updatePositions() to set the vertsChanged flag
-        sprite.updateTransform();
-    }
+		sprite.___hidden = false;
+
+		// Update the vertices.  This will end up caling updatePositions() to set the vertsChanged flag
+		sprite.updateTransform();
+	}
 
 	#endregion;
-	
+
 
 	#region Update UV, colors and positions
-	
-    // Updates the UVs of the specified sprite and copies the new values into the mesh object.
-    public void updateUV( UISprite sprite )
-    {
+
+	// Updates the UVs of the specified sprite and copies the new values into the mesh object.
+	public void updateUV(UISprite sprite)
+	{
 		UVs[sprite.vertexIndices.uv.one] = sprite.uvFrame.lowerLeftUV + Vector2.up * sprite.uvFrame.uvDimensions.y; // Upper-left
 		UVs[sprite.vertexIndices.uv.two] = sprite.uvFrame.lowerLeftUV; // Lower-left
 		UVs[sprite.vertexIndices.uv.three] = sprite.uvFrame.lowerLeftUV + Vector2.right * sprite.uvFrame.uvDimensions.x; // Lower-right
 		UVs[sprite.vertexIndices.uv.four] = sprite.uvFrame.lowerLeftUV + sprite.uvFrame.uvDimensions; // Upper-right
-        
-        uvsChanged = true;
-		meshIsDirty = true;
-    }
-	
 
-    // Updates the color values of the specified sprite and copies the new values into the mesh object.
-    public void updateColors( UISprite sprite )
-    {
+		uvsChanged = true;
+		meshIsDirty = true;
+	}
+
+
+	// Updates the color values of the specified sprite and copies the new values into the mesh object.
+	public void updateColors(UISprite sprite)
+	{
 		colors[sprite.vertexIndices.cv.one] = sprite.color;
 		colors[sprite.vertexIndices.cv.two] = sprite.color;
 		colors[sprite.vertexIndices.cv.three] = sprite.color;
 		colors[sprite.vertexIndices.cv.four] = sprite.color;
 
-        colorsChanged = true;
+		colorsChanged = true;
 		meshIsDirty = true;
-    }
+	}
 
-	
-    // Informs the SpriteManager that some vertices have changed position and the mesh needs to be reconstructed accordingly
-    public void updatePositions()
-    {
-        vertsChanged = true;
+
+	// Informs the SpriteManager that some vertices have changed position and the mesh needs to be reconstructed accordingly
+	public void updatePositions()
+	{
+		vertsChanged = true;
 		meshIsDirty = true;
-    }
+	}
 
 	#endregion;
 

--- a/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
@@ -15,7 +15,10 @@ public struct UITextureInfo
 {
 	public UIUVRect uvRect;
 	public Rect frame;
-	public Rect sourceSize;
+	public Rect spriteSourceSize;
+	public Vector2 sourceSize;
+	public bool trimmed;
+	public bool rotated;
 }
 
 
@@ -121,16 +124,26 @@ public class UISpriteManager : MonoBehaviour
 			var frameH = int.Parse( frame["h"].ToString() );
 		
 			// for trimming support
-			var sourceSize = (Hashtable)((Hashtable)item.Value)["spriteSourceSize"];
-			var sourceSizeX = int.Parse( sourceSize["x"].ToString() );
-			var sourceSizeY = int.Parse( sourceSize["y"].ToString() );
-			var sourceSizeW = int.Parse( sourceSize["w"].ToString() );
-			var sourceSizeH = int.Parse( sourceSize["h"].ToString() );
+			var spriteSourceSize = (Hashtable)((Hashtable)item.Value)["spriteSourceSize"];
+			var spriteSourceSizeX = int.Parse( spriteSourceSize["x"].ToString() );
+			var spriteSourceSizeY = int.Parse( spriteSourceSize["y"].ToString() );
+			var spriteSourceSizeW = int.Parse( spriteSourceSize["w"].ToString() );
+			var spriteSourceSizeH = int.Parse( spriteSourceSize["h"].ToString() );
+
+			var sourceSize = (Hashtable)((Hashtable)item.Value)["sourceSize"];
+			var sourceSizeX = int.Parse(sourceSize["w"].ToString());
+			var sourceSizeY = int.Parse(sourceSize["h"].ToString());
+
+			var trimmed = (bool)((Hashtable)item.Value)["trimmed"];
+			var rotated = (bool)((Hashtable)item.Value)["rotated"];
 			
 			var ti = new UITextureInfo();
 			ti.frame = new Rect( frameX, frameY, frameW, frameH );
 			ti.uvRect = new UIUVRect( frameX, frameY, frameW, frameH, textureSize );
-			ti.sourceSize = new Rect( sourceSizeX, sourceSizeY, sourceSizeW, sourceSizeH );
+			ti.spriteSourceSize = new Rect( spriteSourceSizeX, spriteSourceSizeY, spriteSourceSizeW, spriteSourceSizeH );
+			ti.sourceSize = new Vector2(sourceSizeX, sourceSizeY);
+			ti.trimmed = trimmed;
+			ti.rotated = rotated;
 			
 			textures.Add( item.Key.ToString(), ti );
 		}

--- a/Assets/Plugins/UIToolkit/UIElements/UIText.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UIText.cs
@@ -92,7 +92,7 @@ public class UIText : System.Object
 		// We need to sub out the trimmed amount coming back from the manager.
 		var info = _manager.textureInfoForFilename( textureFilename );
 		
-		this._textureOffset = new Vector2( rect.x - info.sourceSize.x, rect.y - info.sourceSize.y );
+		this._textureOffset = new Vector2( rect.x - info.spriteSourceSize.x, rect.y - info.spriteSourceSize.y );
 	}
 
 	


### PR DESCRIPTION
This set of changes expands the UITextureInfo struct to be able to store all of the data coming from Texture Packer and parses it in.  One field was renamed to maintain consistency with TexturePacker terminology.

The extra information is not used anywhere yet and is the first step towards native support for trimming and TP "rotation".  This should have no backwards compatibility issues.

Take a look, see if this looks okay. :)
