### PR TITLE
Fixed a bug where multiple UIToolkits will overwrite the texture if both using the default material.

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UIObject.cs
@@ -20,6 +20,15 @@ public class UIObject : System.Object, IPositionable
 	protected float _width, _height;
 
 	/// <summary>
+	/// Gets or sets the user data for this object
+	/// </summary>
+	/// <value>
+	/// User data value which can be set at item creation time, and then
+	/// evaluated by event handlers.
+	/// </value>
+	public object userData { get; set; }
+
+	/// <summary>
 	/// Sets up the client GameObject along with it's layer and caches the transform
 	/// </summary>
 	public UIObject()

--- a/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
@@ -90,7 +90,7 @@ public class UISpriteManager : MonoBehaviour
 
 		var texture = (Texture)Resources.Load(texturePackerConfigName, typeof(Texture));
 		if (texture == null)
-			Debug.Log("UI texture is being autoloaded and it doesnt exist.  Cannot find texturePackerConfigName: " + texturePackerConfigName);
+			Debug.Log("UI texture is being autoloaded and it doesn't exist.  Cannot find texturePackerConfigName: " + texturePackerConfigName);
 		material.SetTexture("_MainTex", texture);
 
 		// Cache our texture size

--- a/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
@@ -67,7 +67,13 @@ public class UISpriteManager : MonoBehaviour
 	{
 		_meshFilter = gameObject.AddComponent<MeshFilter>();
 		_meshRenderer = gameObject.AddComponent<MeshRenderer>();
-
+		
+		// Duplicate the standard material so that we're not changing the
+		// supplied one - it may be used by more than one UIToolkit object
+		Material duplicateMaterial = new Material (material.shader);
+		duplicateMaterial.CopyPropertiesFromMaterial(material);
+		material = duplicateMaterial;
+		
 		_meshRenderer.renderer.material = material;
 		_mesh = _meshFilter.mesh;
 

--- a/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs.meta
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs.meta
@@ -1,2 +1,7 @@
-fileFormatVersion: 1
+fileFormatVersion: 2
 guid: aa7854c8e957d4b73ad384a7001c5c8b
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}


### PR DESCRIPTION
Unless I misunderstand the process, I think this is a bug.
To fix, the UIToolkit now takes a copy of the material, rather than use it directly.
