### PR TITLE
Fixed a bug where even though the button was destroyed, it was still fir...

### DIFF
--- a/Assets/Plugins/UIToolkit/UIElements/UIButton.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UIButton.cs
@@ -124,7 +124,18 @@ public class UIButton : UITouchableSprite
 		// If the touch was inside our touchFrame and we have an action, call it
 		if( touchWasInsideTouchFrame && onTouchUpInside != null )
 			onTouchUpInside( this );
-	}
+    }
+
+    public override void destroy()
+    {
+        base.destroy();
+
+        highlighted = false;
+    }
+
+
+
+
 
 
 }


### PR DESCRIPTION
...ing an 'onTouchEnded' event which was calling 'highlight = false;' That altered a property, which called a function to reset the UVs on the mesh. This resetting overwrote the UVs for the next new button sprite.
