### PR TITLE
remove child as touchable from his toolkit not default toolkit from container

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/UIAbstractTouchableContainer.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UIAbstractTouchableContainer.cs
@@ -495,7 +495,7 @@ public abstract class UIAbstractTouchableContainer : UIAbstractContainer, ITouch
 		foreach( var child in children )
 		{
 			if( child is ITouchable )
-				_manager.removeFromTouchables( child as ITouchable );
+				child.manager.removeFromTouchables( child as ITouchable );
 		}
 	}
 	


### PR DESCRIPTION
_manager is default firstToolkit
but child can be from other toolkit
and we must remove from touchables from his toolkit 

Also right maked in in source class UIAbstractContainer, metod removeChild.
