### PR TITLE
UIColorPicker fix to select the _correct_ colour.

### DIFF
--- a/Assets/Plugins/UIToolkit/UIElements/UIColorPicker.cs
+++ b/Assets/Plugins/UIToolkit/UIElements/UIColorPicker.cs
@@ -84,11 +84,11 @@ public class UIColorPicker : UITouchableSprite
 	private Vector2 getTouchTextureCoords( Vector2 touchPos )
 	{
 		float xChange = touchPos.x - position.x;
-		xChange = Mathf.Clamp( xChange, 0, width - 1 );
+		xChange = Mathf.Clamp( xChange + (0.5f * width), 0, width - 1 );
 		float xPos = textureCoords.x + xChange;
 				
-		float yChange = touchPos.y - -1 * ( position.y );
-		yChange = Mathf.Clamp( yChange, 1, height );
+		float yChange = touchPos.y - ( -1 * position.y );
+		yChange = Mathf.Clamp( yChange + (0.5f * height), 1, height );
 		float yPos = manager.textureSize.y - ( textureCoords.y + yChange );
 		
 		return new Vector2( xPos, yPos );


### PR DESCRIPTION
UIColorPicker was behaving incorrectly in selecting incorrect colours
on touch.

I added lots of Debug.Log() statements and figured out that the coordinates were being calculated relative to the middle of the texture rather than top-left (-127 to 128). Therefore I changed the clamp calls to use values which are incremented by half the width of the texture thereby causing the negative values to re-align at 0. With this fix the picker will report x and y coordinates from 0 to 256 (in the instance of the stock picker image) instead of the previous -127 to 128.
