### PR TITLE
Duplicated material will not be assigned to the mesh renderer.

### DIFF
--- a/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
+++ b/Assets/Plugins/UIToolkit/BaseElements/UISpriteManager.cs
@@ -98,6 +98,8 @@ public class UISpriteManager : MonoBehaviour
 		if( texture == null )
 			Debug.Log( "UI texture is being autoloaded and it doesn't exist.  Cannot find texturePackerConfigName: " + texturePackerConfigName );
 		material.mainTexture = texture;
+		// assign the duplicate material to the mesh renderer
+		_meshRenderer.renderer.material = material;
 
 		// Cache our texture size
 		var t = material.mainTexture;


### PR DESCRIPTION
Fixing: assign the duplicate material back to the mesh renderer as it was done before in the awake (pre #150) on Line 78/71.

The bug happens that if an empty Material (valid shader without a texture) is assigned to the UIToolkit, the material gets duplicated, but the shader still has no texture assigned.

This patch does assign the duplicate back to the renderers material.
before patch: http://screencast.com/t/7VFQwFmbKPAV
after patch: http://screencast.com/t/XExJ9KdnQB
